### PR TITLE
Using Ansible os family instead of multiple Ansible os distributions

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -3,6 +3,9 @@ k3s_version: v1.23.4+k3s1
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system
 
+# Set your timezone
+system_timezone: "Your/Timezone"
+
 # interface which will be used for flannel
 flannel_iface: "eth0"
 

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Set SELinux to disabled state
   selinux:
     state: disabled
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+  when: ansible_os_family == "RedHat"
 
 - name: Enable IPv4 forwarding
   sysctl:
@@ -23,13 +23,13 @@
     content: "br_netfilter"
     dest: /etc/modules-load.d/br_netfilter.conf
     mode: "u=rw,g=,o="
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+  when: ansible_os_family == "RedHat"
 
 - name: Load br_netfilter
   modprobe:
     name: br_netfilter
     state: present
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+  when: ansible_os_family == "RedHat"
 
 - name: Set bridge-nf-call-iptables (just to be sure)
   sysctl:
@@ -37,7 +37,7 @@
     value: "1"
     state: present
     reload: yes
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+  when: ansible_os_family == "RedHat"
   loop:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-ip6tables
@@ -50,4 +50,4 @@
     insertafter: EOF
     path: /etc/sudoers
     validate: 'visudo -cf %s'
-  when: ansible_distribution in ['CentOS', 'Red Hat Enterprise Linux']
+  when: ansible_os_family == "RedHat"

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set same timezone on every Server
+  timezone:
+    name: "{{ system_timezone }}"
+  when: (system_timezone is defined) and (system_timezone != "Your/Timezone")
+
 - name: Set SELinux to disabled state
   selinux:
     state: disabled


### PR DESCRIPTION
# Hello Message
Hello Tim

I'm a swiss systemengineer who likes your content, I was accually also writing my own k3s ansible playbooks in the last week, but it is not as extensive as your forked one. I do this pull request only for learning, but if you like the change you can test it and merge. I do not need it working like that, cause I want to finish my own playbook. But maby this change saves someone who uses AlmaLinux or Rocky some time.

Attention: These changes are 100% untested, but it should work like that.

Kind Regards

~Janic 

# Proposed Changes
I replaced the matching distributions from centos and redhat to matching os family (Redhat) cause this includes also some addtional distributions.

# Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [ ] 🚀
