### PR TITLE
Added Vagrantfile for build environment with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ scp debian@master_ip:~/.kube/config ~/.kube/config
 
 See the commands [here](https://docs.technotim.live/posts/k3s-etcd-ansible/#testing-your-cluster).
 
+### Vagrant
+
+You may want to kickstart your k3s cluster by using Vagrant to quickly build you all needed VMs with one command.
+Head to the `vagrant` subfolder and type `vagrant up` to get your environment setup.
+After the VMs have got build, deploy k3s using the Ansible playbook `site.yml` by the
+`vagrant provision --provision-with ansible` command.
+
 ## Thanks 🤝
 This repo is really standing on the shoulders of giants.  To all those who have contributed.
 

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Clean previous runs of k3s-init
   systemd:
     name: k3s-init
@@ -83,7 +84,7 @@
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
       until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
-      retries: 20
+      retries: "{{ retry_count | default(20) }}"
       delay: 10
       changed_when: false
   always:

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,79 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+    # General configuration
+    config.vm.box = "generic/ubuntu2110"
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.ssh.insert_key = false
+
+    config.vm.provider :virtualbox do |v|
+        v.memory = 4096
+        v.cpus = 2
+        v.linked_clone = true
+    end
+
+    # Control Node 1
+    config.vm.define "control1" do |control1|
+        control1.vm.hostname = "control1"
+        control1.vm.network "private_network", ip: "192.168.30.38"
+    end
+
+    # Control Node 2
+    config.vm.define "control2" do |control2|
+        control2.vm.hostname = "control2"
+        control2.vm.network "private_network", ip: "192.168.30.39"
+    end
+
+    # Control Node 3
+    config.vm.define "control3" do |control3|
+        control3.vm.hostname = "control3"
+        control3.vm.network "private_network", ip: "192.168.30.40"
+    end
+
+    # Worker Node 1
+    config.vm.define "node1" do |node1|
+        node1.vm.hostname = "node1"
+        node1.vm.network "private_network", ip: "192.168.30.41"
+    end
+
+    # Worker Node 2
+    config.vm.define "node2" do |node2|
+        node2.vm.hostname = "node2"
+        node2.vm.network "private_network", ip: "192.168.30.42"
+    end
+
+    config.vm.provision "ansible",type: "ansible", run: "never" do |ansible|
+        ansible.playbook = "../site.yml"
+        ansible.limit = "all"
+        ansible.groups = {
+          "master" => ["control1", "control2", "control3"],
+          "node" => ["node1", "node2"],
+          "k3s_cluster:children" => ["master", "node"],
+          "k3s_cluster:vars" => {"k3s_version" => "v1.23.4+k3s1",
+                                 "ansible_user" => "vagrant",
+                                 "systemd_dir" => "/etc/systemd/system",
+                                 "flannel_iface" => "eth1",
+                                 "apiserver_endpoint" => "192.168.30.222",
+                                 "k3s_token" => "supersecret",
+                                 "extra_server_args" => "--node-ip={{ ansible_eth1.ipv4.address }} --flannel-iface={{ flannel_iface }} --no-deploy servicelb --no-deploy traefik",
+                                 "extra_agent_args" => "--flannel-iface={{ flannel_iface }}",
+                                 "kube_vip_tag_version" => "v0.4.2",
+                                 "metal_lb_speaker_tag_version" => "v0.12.1",
+                                 "metal_lb_controller_tag_version" => "v0.12.1",
+                                 "metal_lb_ip_range" => "192.168.30.80-192.168.30.90",
+                                 "retry_count" => "30"}
+        }
+        ansible.host_vars = {
+          "control1" => {
+            "server_init_args" => "--cluster-init --token {{ k3s_token }} {{ extra_server_args | default('') }}"
+          },
+          "control2" => {
+            "server_init_args" => "--server https://192.168.30.38:6443 --token {{ k3s_token }} {{ extra_server_args | default('') }}"
+          },
+          "control3" => {
+            "server_init_args" => "--server https://192.168.30.38:6443 --token {{ k3s_token }} {{ extra_server_args | default('') }}"
+          }
+        }
+    end
+end


### PR DESCRIPTION
# Proposed Changes
I've added a Vagrantfile to the vagrant subdirectory. One may create a working environment by the command `vagrant up` and run the Ansible playbook by the command `vagrant provision --provision-with ansible`.

I also added a section within the README.md regarding the usage of Vagrant and I made the retry_count in the `Verification` section of the master role customizeable (default is still 20).

I made the experience, that the `ubuntu2110` Box Image of Vagrant is not running into a VirtualBox issue so often than other Ubuntu images do. It still happens from time to time, making the VM unresponsive. It is described [here](https://forums.virtualbox.org/viewtopic.php?f=6&t=105047).

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [ ] 🚀
