### PR TITLE
Fixed issue with tasks not running on Debian Bullseye

### DIFF
--- a/roles/raspberrypi/tasks/main.yml
+++ b/roles/raspberrypi/tasks/main.yml
@@ -39,6 +39,14 @@
   when:
     - detected_distribution | default("") == "Raspbian"
 
+- name: Set detected_distribution to Raspbian (ARM64 on Debian Bullseye)
+  set_fact:
+    detected_distribution: Raspbian
+  when:
+    - ansible_facts.architecture is search("aarch64")
+    - raspberry_pi|default(false)
+    - ansible_facts.lsb.description|default("") is match("Debian.*bullseye")
+
 - name: execute OS related tasks on the Raspberry Pi
   include_tasks: "{{ item }}"
   with_first_found:

--- a/roles/raspberrypi/tasks/prereq/Raspbian.yml
+++ b/roles/raspberrypi/tasks/prereq/Raspbian.yml
@@ -7,6 +7,9 @@
     backrefs: true
   notify: reboot
 
+- name: Install iptables
+  apt: name=iptables state=present
+
 - name: Flush iptables before changing to iptables-legacy
   iptables:
     flush: true


### PR DESCRIPTION
# Proposed Changes
Fixes issue with Debian Bullseye on raspberry pi not being detected. So it does no run the Raspbian tasks.

Also added install of iptables if this dependency is missing.
On Debian Buster its installed as default but not on Debian Bullseye.

I have tested it on both Debian Buster and Debian Bullseye

## Checklist

- [X] Tested locally
- [X] Ran `site.yml` playbook
- [X] Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [X] 🚀
