### PR TITLE
Replaced manifest files with double extention to '-'

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: Copy vip rbac manifest to first master
   template:
     src: "vip.rbac.yaml.j2"
-    dest: "/var/lib/rancher/k3s/server/manifests/vip.rbac.yaml"
+    dest: "/var/lib/rancher/k3s/server/manifests/vip-rbac.yaml"
     owner: root
     group: root
     mode: 0644
@@ -43,7 +43,7 @@
 - name: Copy metallb namespace manifest to first master
   template:
     src: "metallb.namespace.j2"
-    dest: "/var/lib/rancher/k3s/server/manifests/metallb.namespace.yaml"
+    dest: "/var/lib/rancher/k3s/server/manifests/metallb-namespace.yaml"
     owner: root
     group: root
     mode: 0644
@@ -52,7 +52,7 @@
 - name: Copy metallb ConfigMap manifest to first master
   template:
     src: "metallb.configmap.j2"
-    dest: "/var/lib/rancher/k3s/server/manifests/metallb.configmap.yaml"
+    dest: "/var/lib/rancher/k3s/server/manifests/metallb-configmap.yaml"
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
# Proposed Changes
I found on v1.24.2+k3s2 any manifest files that had a double extension foo.bar.yaml would not get picked up. I was alerted to this by Kube-VIP not starting due to a missing service account and role binding. Changing the '.' to '-' fixed the issue. I have also run this on the previous K3s to ensure it still works.

## Checklist

- [ X] Tested locally
- [X ] Ran `site.yml` playbook
- [ X] Ran `reset.yml` playbook
- [X ] Did not add any unnecessary changes
- [ ] 🚀
