### PR TITLE
Replace deprecated flag --no-deploy with --disable

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -17,8 +17,8 @@ apiserver_endpoint: "192.168.30.222"
 # this token should be alpha numeric only
 k3s_token: "some-SUPER-DEDEUPER-secret-password"
 
-# change these to your liking, the only required one is--no-deploy servicelb
-extra_server_args: "--no-deploy servicelb --no-deploy traefik"
+# change these to your liking, the only required one is--disable servicelb
+extra_server_args: "--disable servicelb --disable traefik"
 extra_agent_args: ""
 
 # image tag for kube-vip


### PR DESCRIPTION
According to [Kubernetes Components](https://rancher.com/docs/k3s/latest/en/installation/install-options/server-config/#kubernetes-components) section the `--disable <value>` flag should  instead of `--no-deploy <value>` as the latter is listed under [Deprecated Options](https://rancher.com/docs/k3s/latest/en/installation/install-options/server-config/#deprecated-options)

# Proposed Changes
<!--- Provide a general summary of your changes -->

- Edited `inventory/sample/group_vars/all.yml` by replacing `--no-deploy <value>` with `--disable <value>`


## Checklist

- [ x ] Tested locally
- [ x ] Ran `site.yml` playbook
- [ x ] Ran `reset.yml` playbook
- [ x ] Did not add any unnecessary changes
- [ x ] 🚀
