### PR TITLE
Add linux-modules-extra-raspi package for Ubuntu 22.x on Raspberry.

### DIFF
--- a/roles/raspberrypi/tasks/prereq/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/prereq/Ubuntu.yml
@@ -6,3 +6,7 @@
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
   notify: reboot
+
+- name: Install linux-modules-extra-raspi
+  apt: name=linux-modules-extra-raspi state=present
+  when: raspberry_pi

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -51,6 +51,9 @@
   systemd:
     daemon_reload: yes
 
+- name: Remove linux-modules-extra-raspi
+  apt: name=linux-modules-extra-raspi state=absent
+
 - name: Reboot and wait for node to come back up
   reboot:
     reboot_timeout: 3600


### PR DESCRIPTION
Ubuntu 22.x on Raspberry Pi needs the linux-modules-extra-raspi package
for the vxlans kernel module.

# Proposed Changes

K3S on Ubuntu 22.x requires the linux-modules-extra-raspi package for the vxlan kernel module.

NOTE: Not sure if we want to force removal of the linux-modules-extra-raspi package during reset, but included it anyway.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] 🚀
