### PR TITLE
Fix k3s manifest

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -171,3 +171,24 @@
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/crictl
     state: link
+
+- name: get contents of manifests folder
+  find:
+    paths: /var/lib/rancher/k3s/server/manifests
+    file_type: file
+  register: k3s_server_manifests
+
+- name: get sub dirs of manifests folder
+  find:
+    paths: /var/lib/rancher/k3s/server/manifests
+    file_type: directory
+  register: k3s_server_manifests_directories
+
+
+- name: Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: 
+    - "{{ k3s_server_manifests.files }}"
+    - "{{ k3s_server_manifests_directories.files }}"

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -189,6 +189,6 @@
   file:
     path: "{{ item.path }}"
     state: absent
-  with_items: 
+  with_items:
     - "{{ k3s_server_manifests.files }}"
     - "{{ k3s_server_manifests_directories.files }}"

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -172,13 +172,13 @@
     dest: /usr/local/bin/crictl
     state: link
 
-- name: get contents of manifests folder
+- name: Get contents of manifests folder
   find:
     paths: /var/lib/rancher/k3s/server/manifests
     file_type: file
   register: k3s_server_manifests
 
-- name: get sub dirs of manifests folder
+- name: Get sub dirs of manifests folder
   find:
     paths: /var/lib/rancher/k3s/server/manifests
     file_type: directory


### PR DESCRIPTION
This fixes an "issue" that causes manifests to be reapplied each time the k3s service is started.  This will remove the contents of `/var/lib/rancher/k3s/server/manifests` after the cluster has applied the files.

[k3s advanced docs](https://rancher.com/docs/k3s/latest/en/advanced/#:~:text=K3s%20is%20restarted.-,Auto%2DDeploying%20Manifests,-Any%20file%20found)

If you are experiencing this with you cluster, the fix is simple

remove the contents of `/var/lib/rancher/k3s/server/manifests` from each server (leave the manifest files in place).

This closes #51 