### PR TITLE
Print fewer logs when removing manifests

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -192,3 +192,5 @@
   with_items:
     - "{{ k3s_server_manifests.files }}"
     - "{{ k3s_server_manifests_directories.files }}"
+  loop_control:
+    label: "{{ item.path }}"


### PR DESCRIPTION
# Proposed Changes
The new step "Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start" produces lots of log output which looks crowded if your terminal is not super-wide:

```
TASK [../k3s/roles/k3s/master : Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start] ************************
Sunday 21 August 2022  13:25:38 +0200 (0:00:00.521)       0:00:35.185 ********* 
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/vip-rbac.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 805, 'inode': 1840852, 'dev': 26, 'nlink': 1, 'atime': 1661011790.3606591, 'mtime': 1661011772.0407255, 'ctime': 1661011772.5887225, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/vip.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1912, 'inode': 1840862, 'dev': 26, 'nlink': 1, 'atime': 1661011798.8446407, 'mtime': 1661011773.2407193, 'ctime': 1661011773.6087174, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/metallb-namespace.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 95, 'inode': 1840872, 'dev': 26, 'nlink': 1, 'atime': 1661011787.0846677, 'mtime': 1661011774.2487142, 'ctime': 1661011774.6207125, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/metallb-configmap.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 280, 'inode': 1840882, 'dev': 26, 'nlink': 1, 'atime': 1661011787.0766678, 'mtime': 1661011775.2807095, 'ctime': 1661011775.644708, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/metallb.yaml', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 66368, 'inode': 1840892, 'dev': 26, 'nlink': 1, 'atime': 1661011787.1006677, 'mtime': 1661011776.324705, 'ctime': 1661011776.6967032, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/coredns.yaml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 4857, 'inode': 1841538, 'dev': 26, 'nlink': 1, 'atime': 1661081131.7969387, 'mtime': 1661081131.212936, 'ctime': 1661081131.212936, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/local-storage.yaml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 3635, 'inode': 1841539, 'dev': 26, 'nlink': 1, 'atime': 1661081132.09694, 'mtime': 1661081131.212936, 'ctime': 1661081131.212936, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/rolebindings.yaml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1039, 'inode': 1841544, 'dev': 26, 'nlink': 1, 'atime': 1661081132.7569432, 'mtime': 1661081131.2169359, 'ctime': 1661081131.2169359, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/ccm.yaml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1774, 'inode': 1841545, 'dev': 26, 'nlink': 1, 'atime': 1661081131.3889368, 'mtime': 1661081131.212936, 'ctime': 1661081131.212936, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
changed: [some-node] => (item={'path': '/var/lib/rancher/k3s/server/manifests/metrics-server', 'mode': '0700', 'isdir': True, 'ischr': False, 'isblk': False, 'isreg': False, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 330, 'inode': 1841536, 'dev': 26, 'nlink': 1, 'atime': 1661011784.852674, 'mtime': 1661011784.7366743, 'ctime': 1661011784.7366743, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
```

This change condenses the log per loop item down to only the filepath:
```
TASK [../k3s/roles/k3s/master : Remove manifests and folders that are only needed for bootstrapping cluster so k3s doesn't auto apply on start] ************************
Sunday 21 August 2022  13:29:20 +0200 (0:00:00.514)       0:00:35.731 ********* 
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/vip-rbac.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/vip.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/metallb-namespace.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/metallb-configmap.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/metallb.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/rolebindings.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/ccm.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/coredns.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/local-storage.yaml)
changed: [some-node] => (item=/var/lib/rancher/k3s/server/manifests/metrics-server)
```

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] 🚀
