### PR TITLE
add ansible.posix module to requirements.yml

### DIFF
--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - name: community.general
+  - name: ansible.posix


### PR DESCRIPTION
# Add ansible.posix module to requirements.yml

[prereq role](https://github.com/techno-tim/k3s-ansible/blob/1ce3319087cafaff7889ba2b68f9dc0326815fa3/roles/prereq/tasks/main.yml#L8) use [selinux module](https://docs.ansible.com/ansible/latest/collections/ansible/posix/selinux_module.html) but module is not in requirements.yml.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] 🚀
