### PR TITLE
Fix master node taints in multi node installs

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -22,6 +22,8 @@ k3s_token: "some-SUPER-DEDEUPER-secret-password"
 # it for each of your hosts, though.
 k3s_node_ip: '{{ ansible_facts[flannel_iface]["ipv4"]["address"] }}'
 
+k3s_single_node: "{{ 'true' if groups['k3s_cluster'] | length == 1 else 'false' }}"
+
 # these arguments are recommended for servers as well as agents:
 extra_args: >-
   --flannel-iface={{ flannel_iface }}

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -64,7 +64,8 @@
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
-                      k3s server {{ server_init_args }}"
+                      k3s server {{ server_init_args }} \
+                      {{ '--node-taint CriticalAddonsOnly=true:NoExecute' if k3s_single_node|bool == false else ''}}"
     creates: "{{ systemd_dir }}/k3s.service"
   args:
     warn: false  # The ansible systemd module does not support transient units

--- a/roles/k3s/master/templates/k3s.service.j2
+++ b/roles/k3s/master/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server {{ extra_server_args | default("") }}
+ExecStart=/usr/local/bin/k3s server {{ extra_server_args | default("") }} {{ '--node-taint CriticalAddonsOnly=true:NoExecute' if k3s_single_node|bool == false else ''}}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s/master/templates/metallb.crds.j2
+++ b/roles/k3s/master/templates/metallb.crds.j2
@@ -1648,6 +1648,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
         operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/roles/k3s/master/templates/vip.yaml.j2
+++ b/roles/k3s/master/templates/vip.yaml.j2
@@ -69,6 +69,8 @@ spec:
         operator: Exists
       - effect: NoExecute
         operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
   updateStrategy: {}
 status:
   currentNumberScheduled: 0


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Enable the playbook to automatically determine if install has more than one host
- Based on host count decide to apply "CriticalAddonsOnly=true:NoExecute" to masters or not
- Main variable in variables file to allow it to be overwritten
- Should resolve node taint issues in #75

## Checklist

- [X] Tested locally
- [X] Ran `site.yml` playbook
- [X] Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [X] 🚀
