### PR TITLE
Copy Good kube config to nodes from first master

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -64,8 +64,7 @@
     cmd: "systemd-run -p RestartSec=2 \
                       -p Restart=on-failure \
                       --unit=k3s-init \
-                      k3s server {{ server_init_args }} \
-                      {{ '--node-taint CriticalAddonsOnly=true:NoExecute' if k3s_single_node|bool == false else ''}}"
+                      k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
   args:
     warn: false  # The ansible systemd module does not support transient units
@@ -153,12 +152,19 @@
     owner: "{{ ansible_user }}"
     mode: "u=rw,g=,o="
 
-- name: Configure kubectl cluster to https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443
+- name: Configure kubectl cluster to https://{{ apiserver_endpoint }}:6443
   command: >-
     k3s kubectl config set-cluster default
-      --server=https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443
+      --server=https://{{ apiserver_endpoint }}:6443
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
+
+- name: Fetch cluster config file from first master to push to agent nodes - allowing agent nodes to run k3s kubectl xxx (patching, convenience)
+  ansible.builtin.fetch:
+    src: ~{{ ansible_user }}/.kube/config
+    flat: true
+    dest: /tmp/kube_config.{{ apiserver_endpoint }}
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
 - name: Create kubectl symlink
   file:

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -14,3 +14,19 @@
     daemon_reload: yes
     state: restarted
     enabled: yes
+
+- name: Create directory /etc/rancher/k3s on agent node
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: "root"
+    mode: "u=rwx,g=rx,o=rx"
+
+- name: push back a copy of the kubeconfig
+  ansible.builtin.copy:
+    src: /tmp/kube_config.{{ apiserver_endpoint }}
+    dest: /etc/rancher/k3s/k3s.yaml
+    mode: "u=rw,g=r,o=r"
+    owner: root
+    group: root
+


### PR DESCRIPTION


# Proposed Changes
<!--- Provide a general summary of your changes -->
Fetch kube config from master node (using VIP) to /tmp/kube_config.<IP of Master>

Push that file to each agent node so that agent nodes can issue k3s commands and have a configuration. This is useful for patching, etc, when you have an ansible script and you want to drain a node, wait, reboot, check the node status, and uncordon for each patch

## Checklist

- [x ] Tested locally
- [x ] Ran `site.yml` playbook
- [x ] Ran `reset.yml` playbook
- [x ] Did not add any unnecessary changes
- [x ] 🚀
