### PR TITLE
allow not specifying master inventory

### DIFF
--- a/roles/k3s/node/templates/k3s.service.j2
+++ b/roles/k3s/node/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups['master'][0]]['token'] if groups['master'][0] is defined else k3s_token }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

In a scenario where you add nodes/agents in separate runs of Ansible, such as:

Cloud - master(s)/control plane
```
[master]
host1
host2
host3

[node]

[k3s_cluster:children]
master
node
```

On-Prem - node(s)/agent
```
[node]
192.168.64.2

[k3s_cluster:children]
master
node
```

The "On-Prem"/node-only inventory currently fails. Weird because I thought `default` was sort of a try/catch answer for Jinja. 

Error without `[master]` defined in inventory:
```
TASK [k3s/node : Copy K3s service file] ************************************************************************************
Wednesday 21 September 2022  23:48:38 -0500 (0:00:01.121)       0:00:07.521 ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: 'dict object' has no attribute 'master'
fatal: [192.168.64.2]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'master'"}
```

Error with no hosts under `[master]` inventory:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: list object has no element 0
fatal: [192.168.64.2]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: list object has no element 0"}
```



## Checklist

- [ x] Tested locally
- [ x] Ran `site.yml` playbook
- [ x] Ran `reset.yml` playbook
- [ x] Did not add any unnecessary changes
- [ x] 🚀
