### PR TITLE
Change to push the vip-enabled kube config to each node

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -160,6 +160,13 @@
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
+- name: Fetch cluster config file from first master to push to agent nodes - allowing agent nodes to run k3s kubectl xxx (patching, convenience)
+  ansible.builtin.fetch:
+    src: ~{{ ansible_user }}/.kube/config
+    flat: true
+    dest: /tmp/kube_config.{{ apiserver_endpoint }}
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
 - name: Create kubectl symlink
   file:
     src: /usr/local/bin/k3s
@@ -193,3 +200,5 @@
     - "{{ k3s_server_manifests_directories.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -14,3 +14,20 @@
     daemon_reload: yes
     state: restarted
     enabled: yes
+
+
+- name: Create directory /etc/rancher/k3s on agent node
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: "root"
+    mode: "u=rwx,g=rx,o=rx"
+
+- name: push back a copy of the kubeconfig
+  ansible.builtin.copy:
+    src: /tmp/kube_config.{{ apiserver_endpoint }}
+    dest: /etc/rancher/k3s/k3s.yaml
+    mode: "u=rw,g=r,o=r"
+    owner: root
+    group: root
+


### PR DESCRIPTION

# Proposed Changes
<!--- Provide a general summary of your changes -->
Copies the updated master kube config file with the VIP to each node.
It pulls the file locally into /tmp/kube_config.IP_OF_FIRST_MASTER to copy.  It leaves a copy in /tmp for you to use in your local ~/.kube/config or your method.

This is to allow scripts to use k3s kubectl get node <mynode> to see status, e.g. during patching.  You can locally get information, drain the node, reboot, and uncordon using ansible with all the actions running on the node.  Without this, it's hard to see when the node returns to working status and is ready to take activities and move on to the next node.

## Checklist

- [x ] Tested locally
- [ x] Ran `site.yml` playbook
- [ x] Ran `reset.yml` playbook
- [ x] Did not add any unnecessary changes
- [ x] 🚀
