### PR TITLE
Reset fixes when you have secondary storage off the main / with symlinks

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -160,6 +160,13 @@
       --kubeconfig ~{{ ansible_user }}/.kube/config
   changed_when: true
 
+- name: Fetch cluster config file from first master to push to agent nodes - allowing agent nodes to run k3s kubectl xxx (patching, convenience)
+  ansible.builtin.fetch:
+    src: ~{{ ansible_user }}/.kube/config
+    flat: true
+    dest: /tmp/kube_config.{{ apiserver_endpoint }}
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+
 - name: Create kubectl symlink
   file:
     src: /usr/local/bin/k3s
@@ -193,3 +200,5 @@
     - "{{ k3s_server_manifests_directories.files }}"
   loop_control:
     label: "{{ item.path }}"
+
+

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -14,3 +14,20 @@
     daemon_reload: yes
     state: restarted
     enabled: yes
+
+
+- name: Create directory /etc/rancher/k3s on agent node
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: "root"
+    mode: "u=rwx,g=rx,o=rx"
+
+- name: push back a copy of the kubeconfig
+  ansible.builtin.copy:
+    src: /tmp/kube_config.{{ apiserver_endpoint }}
+    dest: /etc/rancher/k3s/k3s.yaml
+    mode: "u=rw,g=r,o=r"
+    owner: root
+    group: root
+

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -29,20 +29,44 @@
   loop_control:
     loop_var: mounted_fs
 
+#
+# it may become or be a common practice to separate /var/lib/rancher and /var/lib/kubelet into their own volumes.  Maybe it would be better to just move /var altogether, but that's not
+# terribly convenient for remote or headless machines (e.g. raspberry pi compute modules, embedded in Turing Pi or Desk Pi where you can't get to single user mode.
+# Recommendation, in this case, is to mount a new volume, such as /k3s-data or similar and symlink /var/lib/rancher and /var/lib/kubelet into directories 
+# other k3s data points like /run/k3s are small/transient/in memory and shouldn't be on a volume
+# 
+# The approach is to delete the files in the folders first, then remove the folders/files that are not symlinks in the follow up
+#
+- name: find service files within the directories that can by symlinks, binaries and data for people who have separate volume and symlink for /var/lib/rancher and /var/lib/kubelet
+  ansible.builtin.find:
+    paths:
+      - /var/lib/rancher/
+      - /var/lib/kubelet/
+    hidden: true
+    recurse: false
+    file_type: any
+  register: to_delete_files
+
+- name: find service files, binaries and data for people who have separate volume and symlink for /var/lib/rancher and /var/lib/kubelet
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  ignore_errors: true
+  with_items: "{{ to_delete_files.files }}"
+
 - name: Remove service files, binaries and data
-  file:
+  ansible.builtin.file:
     name: "{{ item }}"
     state: absent
+  ignore_errors: true
   with_items:
     - /usr/local/bin/k3s
     - "{{ systemd_dir }}/k3s.service"
     - "{{ systemd_dir }}/k3s-node.service"
-    - /etc/rancher/k3s
     - /run/k3s
     - /run/flannel
     - /etc/rancher/
-    - /var/lib/kubelet
-    - /var/lib/rancher/k3s
+    - /var/lib/kubelet/
     - /var/lib/rancher/
     - /var/lib/cni/
 
@@ -61,3 +85,4 @@
 - name: Reboot and wait for node to come back up
   reboot:
     reboot_timeout: 3600
+


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
So this one is -- well a bit more complex and maybe something different is correct.  For my setup, I have
/var/lib/rancher symlinked to /k3s-data/rancher
and
/var/lib/kubelet symlinked to /k3s-data/kubelet

This is to move the bulk of the data off the RPI's EMMC/SD card and keep etcd data off the card, which I understand is a good thing (e.g. leaving etcd on the card is a bad thing).  There may be better ways to move these volumes off the main storage, but this seems to make sense to me.  

In either case, the reset.yaml would fail because it didn't want to delete symlinks and it would also clear/delete the kubelet symlink because of the lack of the trailing / on that folder.

The fix is to take the folders that *may* be symlinked (logically) and use ansible find to get the list and delete the files in a loop later.  Not pretty, and maybe there's a better way, but this seemed to fit the bill.

Comments/thoughts welcome...

Happy to share my kuebprep script that sets up each of them using /dev/sda as a volume and does all the linking, leaving some space for longhorn as well... 

-
-
-

## Checklist

- [ x] Tested locally
- [ x] Ran `site.yml` playbook
- [ x Ran `reset.yml` playbook
- [ x] Did not add any unnecessary changes
- [ x] 🚀
