### PR TITLE
Add "collection" to the ansible-galaxy command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ on processor architecture:
 
 - `server` and `agent` nodes should have passwordless SSH access, if not you can supply arguments to provide credentials `--ask-pass --ask-become-pass` to each command.
 
-- You will also need to install collections that this playbook uses by running `ansible-galaxy install -r ./collections/requirements.yml`
+- You will also need to install collections that this playbook uses by running `ansible-galaxy collection install -r ./collections/requirements.yml`
 
 ## 🚀 Getting Started
 


### PR DESCRIPTION
# Proposed Changes
Add "collection" to the ansible-galaxy command as it will run without making changes if that collection argument is not provided.

With collection argument:
`ansible-galaxy collection install -r ./collections/requirements.yml
Process install dependency map
Starting collection install process
Installing 'ansible.utils:2.6.1' to '/home/user/.ansible/collections/ansible_collections/ansible/utils'
Installing 'community.general:5.6.0' to '/home/user/.ansible/collections/ansible_collections/community/general'
Installing 'ansible.posix:1.4.0' to '/home/user/.ansible/collections/ansible_collections/ansible/posix'
Installing 'kubernetes.core:2.3.2' to '/home/user/.ansible/collections/ansible_collections/kubernetes/core'`

Without collection argument:
`ansible-galaxy install -r ./collections/requirements.yml`
_Command runs without any output to console and no actions taken_

## Checklist

- [X] Tested locally
- [X] Ran `site.yml` playbook
- [X] Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [ ] 🚀
