### PR TITLE
Pre-commit hooks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,4 @@
 - [ ] Ran `reset.yml` playbook
 - [ ] Did not add any unnecessary changes
 - [ ] 🚀
+- [ ] Ran pre-commit install at least once before committing

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 jobs:
-  ansible-lint:
-    name: YAML Lint + Ansible Lint
+  pre-commit-ci:
+    name: Pre-Commit
     runs-on: ubuntu-latest
 
     steps:
@@ -34,8 +34,5 @@ jobs:
           ansible-galaxy install -r collections/requirements.yml
           echo "::endgroup::"
 
-      - name: Run yamllint
-        run: yamllint .
-
-      - name: Run ansible-lint
-        run: ansible-lint
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: requirements-txt-fixer
+      - id: sort-simple-yaml
+      - id: detect-private-key
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.28.0
+    hooks:
+      - id: yamllint
+        args: [-c=.yamllint]
+  - repo: https://github.com/ansible-community/ansible-lint.git
+    rev: v6.8.2
+    hooks:
+      - id: ansible-lint
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.8.0.4
+    hooks:
+      - id: shellcheck

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pathspec==0.10.1
 pkgutil-resolve-name==1.3.10
 platformdirs==2.5.2
 pluggy==1.0.0
+pre-commit=2.20.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pathspec==0.10.1
 pkgutil-resolve-name==1.3.10
 platformdirs==2.5.2
 pluggy==1.0.0
-pre-commit=2.20.0
+pre-commit==2.20.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pycparser==2.21


### PR DESCRIPTION
# Proposed Changes

- Added [Pre-commit](https://github.com/pre-commit) to the project
- Added yamllint, ansible-lint, shellcheck and requirements.txt sorter
- Updated the PULL_REQUEST_TEMPLATE to ask about pre-commit
- Updated GitHub Actions lint job to run pre-commit 

I would've removed the GitHub Action lint job altogether in favor of [pre-commit.ci](http://pre-commit.ci/) but there is a bug there where ansible galaxy fails to install the requirements.yml [here](https://results.pre-commit.ci/run/github/555747600/1666428009.sf2LdDhNRR-Nb0UyfMk9yQ)

I did not run all the checks because these are minor changes that do not affect the current k3s setup and I'm on my laptop in at the university now. If someone wants to volunteer and try to run the `site.yml` and `reset.yml` would be cool. The molecule tests are passing on my fork.

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] 🚀
