### PR TITLE
"command" module no longer supports "warn" argument

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Clean previous runs of k3s-init
   systemd:
     name: k3s-init
@@ -10,7 +11,7 @@
   failed_when: false
   changed_when: false
   args:
-    warn: false # The ansible systemd module does not support reset-failed
+    warn: false  # The ansible systemd module does not support reset-failed
 
 - name: Create manifests directory on first master
   file:
@@ -61,12 +62,10 @@
 - name: Init cluster inside the transient k3s-init service
   command:
     cmd: "systemd-run -p RestartSec=2 \
-      -p Restart=on-failure \
-      --unit=k3s-init \
-      k3s server {{ server_init_args }}"
+                      -p Restart=on-failure \
+                      --unit=k3s-init \
+                      k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
-  #args:
-  #warn: false  # The ansible systemd module does not support transient units
 
 - name: Verification
   block:

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Clean previous runs of k3s-init
   systemd:
     name: k3s-init
@@ -11,7 +10,7 @@
   failed_when: false
   changed_when: false
   args:
-    warn: false  # The ansible systemd module does not support reset-failed
+    warn: false # The ansible systemd module does not support reset-failed
 
 - name: Create manifests directory on first master
   file:
@@ -62,12 +61,12 @@
 - name: Init cluster inside the transient k3s-init service
   command:
     cmd: "systemd-run -p RestartSec=2 \
-                      -p Restart=on-failure \
-                      --unit=k3s-init \
-                      k3s server {{ server_init_args }}"
+      -p Restart=on-failure \
+      --unit=k3s-init \
+      k3s server {{ server_init_args }}"
     creates: "{{ systemd_dir }}/k3s.service"
-  args:
-    warn: false  # The ansible systemd module does not support transient units
+  #args:
+  #warn: false  # The ansible systemd module does not support transient units
 
 - name: Verification
   block:


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
new ansible version causes error 
```
msg: 'Unsupported parameters for (ansible.legacy.command) module: warn. Supported parameters include: creates, removes, strip_empty_ends, chdir, _uses_shell, _raw_params, stdin_add_newline, argv, stdin, executable.'
```

- This change simple removed the "warn" arg to avoid the fata error from ansible.
- Some autoformat indentation and extra space removed by vscode.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
