### PR TITLE
fix: config warning callback_whitelist

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -9,7 +9,7 @@ local_tmp               = $HOME/.ansible/tmp
 timeout                 = 60
 host_key_checking       = False
 deprecation_warnings    = False
-callback_whitelist      = profile_tasks
+callbacks_enabled       = profile_tasks
 log_path                = ./ansible.log
 
 [privilege_escalation]


### PR DESCRIPTION
# Proposed Changes
When using the ansible playbook with the deprecation_warnings flag on I got this warning:
```
[DEPRECATION WARNING]: [defaults]callback_whitelist option, normalizing names to new standard, use
callbacks_enabled instead. This feature will be removed from ansible-core in version 2.15.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
This is the replacement for callback_whitelist

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
