### PR TITLE
Typo: Should say manifest instead of namespace

### DIFF
--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -50,7 +50,7 @@
     mode: 0644
   when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
-- name: Copy metallb namespace to first master
+- name: Copy metallb manifest to first master
   template:
     src: "metallb.crds.j2"
     dest: "/var/lib/rancher/k3s/server/manifests/metallb-crds.yaml"


### PR DESCRIPTION
Simple enough.  I've catch a typo.

## Checklist

- [X] Tested locally
- [X] Ran `site.yml` playbook
- [X] Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [X] Ran pre-commit install at least once before committing
- [X] 🚀
