### PR TITLE
Do not rely on ansible_user

### DIFF
--- a/reboot.yml
+++ b/reboot.yml
@@ -2,8 +2,8 @@
 - name: Reboot k3s_cluster
   hosts: k3s_cluster
   gather_facts: yes
-  become: yes
   tasks:
     - name: Reboot the nodes (and Wait upto 5 mins max)
+      become: true
       reboot:
         reboot_timeout: 300

--- a/reset.yml
+++ b/reset.yml
@@ -2,12 +2,14 @@
 
 - hosts: k3s_cluster
   gather_facts: yes
-  become: yes
   roles:
     - role: reset
+      become: true
     - role: raspberrypi
+      become: true
       vars: {state: absent}
   post_tasks:
     - name: Reboot and wait for node to come back up
+      become: true
       reboot:
         reboot_timeout: 3600

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-ansible_user: root
 server_init_args: >-
   {% if groups['master'] | length > 1 %}
     {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}

--- a/roles/k3s/master/tasks/main.yml
+++ b/roles/k3s/master/tasks/main.yml
@@ -97,24 +97,24 @@
 
 - name: Create directory .kube
   file:
-    path: ~{{ ansible_user }}/.kube
+    path: "{{ ansible_user_dir }}/.kube"
     state: directory
-    owner: "{{ ansible_user }}"
+    owner: "{{ ansible_user_id }}"
     mode: "u=rwx,g=rx,o="
 
 - name: Copy config file to user home directory
   copy:
     src: /etc/rancher/k3s/k3s.yaml
-    dest: ~{{ ansible_user }}/.kube/config
+    dest: "{{ ansible_user_dir }}/.kube/config"
     remote_src: yes
-    owner: "{{ ansible_user }}"
+    owner: "{{ ansible_user_id }}"
     mode: "u=rw,g=,o="
 
 - name: Configure kubectl cluster to {{ endpoint_url }}
   command: >-
     k3s kubectl config set-cluster default
       --server={{ endpoint_url }}
-      --kubeconfig ~{{ ansible_user }}/.kube/config
+      --kubeconfig {{ ansible_user_dir }}/.kube/config
   changed_when: true
   vars:
     endpoint_url: >-

--- a/roles/k3s/post/tasks/metallb.yml
+++ b/roles/k3s/post/tasks/metallb.yml
@@ -3,7 +3,7 @@
   file:
     path: /tmp/k3s
     state: directory
-    owner: "{{ ansible_user }}"
+    owner: "{{ ansible_user_id }}"
     mode: 0755
   with_items: "{{ groups['master'] }}"
   run_once: true
@@ -12,7 +12,7 @@
   template:
     src: "metallb.crs.j2"
     dest: "/tmp/k3s/metallb-crs.yaml"
-    owner: "{{ ansible_user }}"
+    owner: "{{ ansible_user_id }}"
     mode: 0755
   with_items: "{{ groups['master'] }}"
   run_once: true

--- a/site.yml
+++ b/site.yml
@@ -2,23 +2,25 @@
 
 - hosts: k3s_cluster
   gather_facts: yes
-  become: yes
   roles:
     - role: prereq
+      become: true
     - role: download
+      become: true
     - role: raspberrypi
+      become: true
 
 - hosts: master
-  become: yes
   roles:
     - role: k3s/master
+      become: true
 
 - hosts: node
-  become: yes
   roles:
     - role: k3s/node
+      become: true
 
 - hosts: master
-  become: yes
   roles:
     - role: k3s/post
+      become: true


### PR DESCRIPTION
# Proposed Changes

Instead of reading `ansible_user` (which may or may not be defined), this patch lets the roles rely on [Ansible facts](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_vars_facts.html).

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
