### PR TITLE
Change snapshotter to native driver if LXC is using zfs backend

### DIFF
--- a/roles/lxc/tasks/main.yml
+++ b/roles/lxc/tasks/main.yml
@@ -5,3 +5,15 @@
     dest: "/etc/rc.local"
     mode: "u=rwx,g=rx,o=rx"
   notify: reboot server
+
+- name: Validate K3S storage backend
+  shell: 
+    cmd: df -T /var/lib/ | sed 1d | awk '{print $2}'
+  register: storagebackend
+
+- name: Change snapshot driver to zfs
+  set_fact:
+    extra_server_args: >-
+      {{ extra_server_args }}
+      --snapshotter=native
+  when: storagebackend.stdout == "zfs"


### PR DESCRIPTION
# Proposed Changes
Fixes https://github.com/techno-tim/k3s-ansible/issues/230

If using LXC containers on Proxmox with a ZFS pool, the overlay driver will cause k3s to not start which will cause failure to deploy. This corrects that behavior by checking for /var/lib to be backed by zfs and changes the snapshot driver to native.

This is part of the lxc role, so this will not affect any bare metal deployments. This is intentional as I did not validate bare metal deployments.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
