### PR TITLE
Fix dual-stack clusters with multiple master nodes

### DIFF
--- a/molecule/ipv6/host_vars/control2.yml
+++ b/molecule/ipv6/host_vars/control2.yml
@@ -1,0 +1,3 @@
+---
+node_ipv4: 192.168.123.12
+node_ipv6: fdad:bad:ba55::de:12

--- a/molecule/ipv6/molecule.yml
+++ b/molecule/ipv6/molecule.yml
@@ -4,7 +4,6 @@ dependency:
 driver:
   name: vagrant
 platforms:
-
   - name: control1
     box: generic/ubuntu2204
     memory: 2048
@@ -15,6 +14,22 @@ platforms:
     interfaces:
       - network_name: private_network
         ip: fdad:bad:ba55::de:11
+    config_options:
+      # We currently can not use public-key based authentication on Ubuntu 22.04,
+      # see: https://github.com/chef/bento/issues/1405
+      ssh.username: "vagrant"
+      ssh.password: "vagrant"
+
+  - name: control2
+    box: generic/ubuntu2204
+    memory: 2048
+    cpus: 2
+    groups:
+      - k3s_cluster
+      - master
+    interfaces:
+      - network_name: private_network
+        ip: fdad:bad:ba55::de:12
     config_options:
       # We currently can not use public-key based authentication on Ubuntu 22.04,
       # see: https://github.com/chef/bento/issues/1405

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -4,7 +4,7 @@ server_init_args: >-
     {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}
       --cluster-init
     {% else %}
-      --server https://{{ hostvars[groups['master'][0]].k3s_node_ip }}:6443
+      --server https://{{ hostvars[groups['master'][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
     {% endif %}
     --token {{ k3s_token }}
   {% endif %}


### PR DESCRIPTION
# Proposed Changes

In its current form, the playbook cannot manage dual-stack multi-master clusters. The reason for this is every master other than the first get a URL parameter which includes `k3s_node_ip` of the first master verbatim. Since `k3s_node_ip` contains multiple, comma-separated IP addresses in dual-stack clusters, we need to extract a single IP address here.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
