### PR TITLE
Pick kube-vip interface automatically by default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Test with molecule
         run: molecule test --scenario-name ${{ matrix.scenario }}
+        timeout-minutes: 90
         env:
           ANSIBLE_K3S_LOG_DIR: ${{ runner.temp }}/logs/k3s-ansible/${{ matrix.scenario }}
           ANSIBLE_SSH_RETRIES: 4

--- a/molecule/ipv6/overrides.yml
+++ b/molecule/ipv6/overrides.yml
@@ -7,6 +7,11 @@
         # See: https://github.com/flannel-io/flannel/blob/67d603aaf45ef80f5dd39f43714fc5e6f8a637eb/Documentation/troubleshooting.md#Vagrant  # noqa yaml[line-length]
         flannel_iface: eth1
 
+        # In this scenario, we have multiple interfaces that the VIP could be
+        # broadcasted on. Since we have assigned a dedicated private network
+        # here, let's make sure that it is used.
+        kube_vip_iface: eth1
+
         # The test VMs might be a bit slow, so we give them more time to join the cluster:
         retry_count: 45
 

--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# If you want to explicitly define an interface that ALL control nodes
+# should use to propagate the VIP, define it here. Otherwise, kube-vip
+# will determine the right interface automatically at runtime.
+kube_vip_iface: null
+
 server_init_args: >-
   {% if groups['master'] | length > 1 %}
     {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}

--- a/roles/k3s/master/templates/vip.yaml.j2
+++ b/roles/k3s/master/templates/vip.yaml.j2
@@ -30,8 +30,10 @@ spec:
           value: "true"
         - name: port
           value: "6443"
+{% if kube_vip_iface %}
         - name: vip_interface
-          value: {{ flannel_iface }}
+          value: {{ kube_vip_iface }}
+{% endif %}
         - name: vip_cidr
           value: "{{ apiserver_endpoint | ansible.utils.ipsubnet | ansible.utils.ipaddr('prefix') }}"
         - name: cp_enable


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Currently, it is not possible to use multiple control nodes where the network interfaces to use have different names. This is due to the fact that `{{ flannel_iface }}` of the first control node will be hardcoded into the kube-vip manifest as the interface that all kube-vip pods must use.
- kube-vip is able to pick a matching interface per pod automatically for a ["long time"](https://github.com/kube-vip/kube-vip/issues/273#issuecomment-1310337093).
- This patch enables the automatic choice of interface by default and offers users the ability to override the interface if they want to (independently of `flannel_iface`, as requested in #221.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
