### PR TITLE
Simplify download and patching of MetalLB manifests

### DIFF
--- a/roles/k3s/master/tasks/metallb.yml
+++ b/roles/k3s/master/tasks/metallb.yml
@@ -8,25 +8,16 @@
     mode: 0644
   when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
-- name: Download metallb manifest to first master
+- name: "Download to first master: manifest for metallb-{{ metal_lb_type }}"
   ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/metallb/metallb/{{ metal_lb_controller_tag_version }}/config/manifests/metallb-native.yaml"  # noqa yaml[line-length]
+    url: "https://raw.githubusercontent.com/metallb/metallb/{{ metal_lb_controller_tag_version }}/config/manifests/metallb-{{metal_lb_type}}.yaml"  # noqa yaml[line-length]
     dest: "/var/lib/rancher/k3s/server/manifests/metallb-crds.yaml"
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] and metal_lb_type == "native"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
 
-- name: Download metallb-frr manifest to first master
-  ansible.builtin.get_url:
-    url: "https://raw.githubusercontent.com/metallb/metallb/{{ metal_lb_controller_tag_version }}/config/manifests/metallb-frr.yaml"  # noqa yaml[line-length]
-    dest: "/var/lib/rancher/k3s/server/manifests/metallb-frr-crds.yaml"
-    owner: root
-    group: root
-    mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] and metal_lb_type == "frr"
-
-- name: Set image versions for metallb manifest
+- name: Set image versions in manifest for metallb-{{ metal_lb_type }}
   ansible.builtin.replace:
     path: "/var/lib/rancher/k3s/server/manifests/metallb-crds.yaml"
     regexp: "{{ item.change | ansible.builtin.regex_escape }}"
@@ -36,16 +27,4 @@
       to: "metallb/speaker:{{ metal_lb_speaker_tag_version }}"
   loop_control:
     label: "{{ item.change }} => {{ item.to }}"
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] and metal_lb_type == "native"
-
-- name: Set image versions for metallb-frr manifest
-  ansible.builtin.replace:
-    path: "/var/lib/rancher/k3s/server/manifests/metallb-frr-crds.yaml"
-    regexp: "{{ item.change | ansible.builtin.regex_escape }}"
-    replace: "{{ item.to }}"
-  with_items:
-    - change: "metallb/speaker:{{ metal_lb_controller_tag_version }}"
-      to: "metallb/speaker:{{ metal_lb_speaker_tag_version }}"
-  loop_control:
-    label: "{{ item.change }} => {{ item.to }}"
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] and metal_lb_type == "frr"
+  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']


### PR DESCRIPTION
# Proposed Changes
This patch removes duplicated code and cleans up Ansible log lines a bit.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
