### PR TITLE
Chore: Update kube vip and MetalLB

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -56,8 +56,8 @@ metal_lb_mode: "layer2"
 
 # image tag for metal lb
 metal_lb_frr_tag_version: "v7.5.1"
-metal_lb_speaker_tag_version: "v0.13.7"
-metal_lb_controller_tag_version: "v0.13.7"
+metal_lb_speaker_tag_version: "v0.13.9"
+metal_lb_controller_tag_version: "v0.13.9"
 
 # metallb ip range for load balancer
 metal_lb_ip_range: "192.168.30.80-192.168.30.90"

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -41,7 +41,7 @@ extra_agent_args: >-
   {{ extra_args }}
 
 # image tag for kube-vip
-kube_vip_tag_version: "v0.5.7"
+kube_vip_tag_version: "v0.5.11"
 
 # metallb type frr or native
 metal_lb_type: "native"


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

```yaml
# image tag for kube-vip
kube_vip_tag_version: "v0.5.11"

# image tag for metal lb
metal_lb_speaker_tag_version: "v0.13.9"
metal_lb_controller_tag_version: "v0.13.9"
```

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
