### PR TITLE
fix reset.yml for lxc containers, add support for extra worker packages

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -40,6 +40,10 @@ extra_server_args: >-
 extra_agent_args: >-
   {{ extra_args }}
 
+extra_worker_packages: []
+# - open-iscsi  # for longhorn
+# - nfs-common  # for longhorn backups
+
 # image tag for kube-vip
 kube_vip_tag_version: "v0.5.11"
 

--- a/molecule/default/overrides.yml
+++ b/molecule/default/overrides.yml
@@ -9,3 +9,7 @@
 
         # The test VMs might be a bit slow, so we give them more time to join the cluster:
         retry_count: 45
+
+        extra_worker_packages:
+          - open-iscsi
+          - nfs-common

--- a/molecule/default/tests/test_default_node.py
+++ b/molecule/default/tests/test_default_node.py
@@ -1,0 +1,16 @@
+import os
+import pytest
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('node')
+
+
+@pytest.mark.parametrize('pkg', [
+    'open-iscsi',
+    'nfs-common',
+])
+def test_pkg(host, pkg):
+    package = host.package(pkg)
+    assert package.is_installed

--- a/reset.yml
+++ b/reset.yml
@@ -17,7 +17,6 @@
 - hosts: proxmox
   gather_facts: true
   become: yes
-  remote_user: "{{ proxmox_lxc_ssh_user }}"
   roles:
     - role: reset_proxmox_lxc
       when: proxmox_lxc_configure

--- a/roles/k3s/node/tasks/main.yml
+++ b/roles/k3s/node/tasks/main.yml
@@ -14,3 +14,8 @@
     daemon_reload: yes
     state: restarted
     enabled: yes
+
+- name: install extra worker node packages
+  package:
+    name: "{{ extra_worker_packages }}"
+    state: present

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -82,3 +82,8 @@
     path: /etc/rc.local
     state: absent
   when: proxmox_lxc_configure and rcfile.stat.exists and ((rcslurp.content | b64decode).splitlines() | length) <= 1
+
+- name: remove extra worker node packages
+  package:
+    name: "{{ extra_worker_packages }}"
+    state: absent


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- implements https://github.com/techno-tim/k3s-ansible/discussions/259
- fixes the reset script for lxc containers, ref: https://github.com/techno-tim/k3s-ansible/pull/263

Tested by deploying to a test cluster with the following extra packages, and verifying they were present by using `apt list --installed | grep <package name>`. Also ran the reset script and verified that they were uninstalled using the same method.

```
extra_worker_packages:
- open-iscsi  # for longhorn
- nfs-common  # for longhorn backups

```

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
