### PR TITLE
Bump k3s version to v1.24.12+k3s1

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.24.11+k3s1
+k3s_version: v1.24.12+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system


### PR DESCRIPTION
# Proposed Changes
Bump k3s version from v1.24.11+k3s1 to v1.24.12+k3s1

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
