### PR TITLE
Update main.yml

### DIFF
--- a/roles/k3s/master/defaults/main.yml
+++ b/roles/k3s/master/defaults/main.yml
@@ -9,7 +9,7 @@ server_init_args: >-
     {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}
       --cluster-init
     {% else %}
-      --server https://{{ hostvars[groups['master'][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
+      --server https://{{ hostvars[groups['master'][0]].k3s_node_ip.split(",")[0] | ansible.utils.ipwrap }}:6443
     {% endif %}
     --token {{ k3s_token }}
   {% endif %}


### PR DESCRIPTION
Fix Template Runtime Error caused by split filter

# Proposed Changes

- Error that prompted change

TASK [k3s/master : Init cluster inside the transient k3s-init service] *************************************************************************************************************************************************************************************************************************************
fatal: [xxx.xx.x.xx]: FAILED! => {"msg": "An unhandled exception occurred while templating '{% if groups['master'] | length > 1 %}\n  {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}\n    --cluster-init\n  {% else %}\n    --server https://{{ hostvars[groups['master'][0]].k3s_node_ip | split(\",\") | first | ansible.utils.ipwrap }}:6443\n  {% endif %}\n  --token {{ k3s_token }}\n{% endif %} {{ extra_server_args | default('') }}'. Error was a <class 'jinja2.exceptions.TemplateRuntimeError'>, original message: No filter named 'split' found."}

(*IP-removed*) = [xxx.xx.x.xx]

Setup = 2x physical machines for current testing, OS = Ubuntu Server 22.04
Both set as master, Post Fix = tested complete and functional install

## Checklist

- [ Y ] Tested locally
- [ Y ] Ran `site.yml` playbook
- [ Y ] Ran `reset.yml` playbook
- [ Y ] Did not add any unnecessary changes
- [ Y ] Ran pre-commit install at least once before committing
- [ Y ] 🚀