### PR TITLE
fix: Ensure role label on nodes

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -40,6 +40,10 @@ extra_server_args: >-
 extra_agent_args: >-
   {{ extra_args }}
 
+# Extra labels to worker nodes. Could be useful to use additional pod
+# selectors.
+extra_agent_labels: {}
+
 # image tag for kube-vip
 kube_vip_tag_version: "v0.5.12"
 

--- a/roles/k3s/post/tasks/main.yml
+++ b/roles/k3s/post/tasks/main.yml
@@ -13,3 +13,13 @@
   run_once: true
   changed_when: false
   with_items: "{{ groups['node'] }}"
+
+- name: Ensure additional labels on nodes
+  ansible.builtin.command:
+    cmd: "k3s kubectl label node {{ item.0 }} {{ item.1.key }}={{ item.1.value }}"
+  run_once: true
+  changed_when: false
+  loop: "{{ groups['node'] | product(extra_agent_labels | dict2items) | list }}"
+  when:
+    - extra_agent_labels is defined
+    - extra_agent_labels | length > 0

--- a/roles/k3s/post/tasks/main.yml
+++ b/roles/k3s/post/tasks/main.yml
@@ -6,3 +6,10 @@
   file:
     path: /tmp/k3s
     state: absent
+
+- name: Ensure worker role on nodes
+  ansible.builtin.command:
+    cmd: "k3s kubectl label node {{ item }}  node-role.kubernetes.io/worker=worker --overwrite"
+  run_once: true
+  changed_when: false
+  with_items: "{{ groups['node'] }}"


### PR DESCRIPTION
it is generally more pleasant to set these roles.

# Proposed Changes
Ensure the node role is configured as expected instead of beeing none.

```
(.venv) sascha@apu:~/git/dmix/ansible-infra$ k get nodes
NAME        STATUS   ROLES                       AGE   VERSION
...
intkwkr01   Ready    worker                      19d   v1.24.12+k3s1
intkwkr02   Ready    none                     19d   v1.24.12+k3s1
```

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
