### PR TITLE
add ebg multihop true to metallb

### DIFF
--- a/roles/k3s/post/templates/metallb.crs.j2
+++ b/roles/k3s/post/templates/metallb.crs.j2
@@ -33,7 +33,9 @@ spec:
   myASN: {{ metal_lb_bgp_my_asn }}
   peerASN: {{ metal_lb_bgp_peer_asn }}
   peerAddress: {{ metal_lb_bgp_peer_address }}
-
+{% if metal_lb_type == "frr" %}
+  ebgpMultiHop: true
+{% endif %}
 ---
 apiVersion: metallb.io/v1beta1
 kind: BGPAdvertisement


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Adds `ebgpMultiHop: true` to metallb template
- MetalLB in FRR mode does not automatically account for multihop peering and requires [ebgp-multihop](https://metallb.universe.tf/concepts/bgp/#limitations-of-the-frr-mode) flag set to true

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
