### PR TITLE
Replace hardcoded 'master' group name with 'group_name_master' variable

### DIFF
--- a/roles/k3s/node/defaults/main.yml
+++ b/roles/k3s/node/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Name of the master group
+group_name_master: master

--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups['master'][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -4,12 +4,16 @@
 # will determine the right interface automatically at runtime.
 kube_vip_iface: null
 
+# Name of the master group
+group_name_master: master
+
+# yamllint disable rule:line-length
 server_init_args: >-
-  {% if groups['master'] | length > 1 %}
-    {% if ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname'] %}
+  {% if groups[group_name_master | default('master')] | length > 1 %}
+    {% if ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname'] %}
       --cluster-init
     {% else %}
-      --server https://{{ hostvars[groups['master'][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
+      --server https://{{ hostvars[groups[group_name_master | default('master')][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
     {% endif %}
     --token {{ k3s_token }}
   {% endif %}

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -33,7 +33,7 @@
       command:
         cmd: k3s kubectl get nodes -l "node-role.kubernetes.io/master=true" -o=jsonpath="{.items[*].metadata.name}"
       register: nodes
-      until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups['master'] | length)
+      until: nodes.rc == 0 and (nodes.stdout.split() | length) == (groups[group_name_master | default('master')] | length)  # yamllint disable-line rule:line-length
       retries: "{{ retry_count | default(20) }}"
       delay: 10
       changed_when: false

--- a/roles/k3s_server/tasks/metallb.yml
+++ b/roles/k3s_server/tasks/metallb.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: "Download to first master: manifest for metallb-{{ metal_lb_type }}"
   ansible.builtin.get_url:
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: Set image versions in manifest for metallb-{{ metal_lb_type }}
   ansible.builtin.replace:
@@ -27,4 +27,4 @@
       to: "metallb/speaker:{{ metal_lb_speaker_tag_version }}"
   loop_control:
     label: "{{ item.change }} => {{ item.to }}"
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']

--- a/roles/k3s_server/tasks/vip.yml
+++ b/roles/k3s_server/tasks/vip.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: Download vip rbac manifest to first master
   ansible.builtin.get_url:
@@ -15,7 +15,7 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: Copy vip manifest to first master
   template:
@@ -24,4 +24,4 @@
     owner: root
     group: root
     mode: 0644
-  when: ansible_hostname == hostvars[groups['master'][0]]['ansible_hostname']
+  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']

--- a/roles/k3s_server_post/defaults/main.yml
+++ b/roles/k3s_server_post/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # Timeout to wait for MetalLB services to come up
 metal_lb_available_timeout: 120s
+
+# Name of the master group
+group_name_master: master

--- a/roles/k3s_server_post/tasks/metallb.yml
+++ b/roles/k3s_server_post/tasks/metallb.yml
@@ -5,7 +5,7 @@
     state: directory
     owner: "{{ ansible_user_id }}"
     mode: 0755
-  with_items: "{{ groups['master'] }}"
+  with_items: "{{ groups[group_name_master | default('master')] }}"
   run_once: true
 
 - name: Copy metallb CRs manifest to first master
@@ -14,14 +14,14 @@
     dest: "/tmp/k3s/metallb-crs.yaml"
     owner: "{{ ansible_user_id }}"
     mode: 0755
-  with_items: "{{ groups['master'] }}"
+  with_items: "{{ groups[group_name_master | default('master')] }}"
   run_once: true
 
 - name: Test metallb-system namespace
   command: >-
     k3s kubectl -n metallb-system
   changed_when: false
-  with_items: "{{ groups['master'] }}"
+  with_items: "{{ groups[group_name_master | default('master')] }}"
   run_once: true
 
 - name: Wait for MetalLB resources
@@ -66,7 +66,7 @@
   command: >-
     k3s kubectl -n metallb-system get endpoints webhook-service
   changed_when: false
-  with_items: "{{ groups['master'] }}"
+  with_items: "{{ groups[group_name_master | default('master')] }}"
   run_once: true
 
 - name: Apply metallb CRs


### PR DESCRIPTION
# Proposed Changes

For improved flexibility and maintainability.

* Update tasks in node role to use 'group_name_master' variable instead of hardcoded 'master' group name
* Update tasks in master role to use 'group_name_master' variable instead of hardcoded 'master' group name
* Update tasks in post role to use 'group_name_master' variable instead of hardcoded 'master' group name

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
