### PR TITLE
Expand secure_path with support for Suse

### DIFF
--- a/roles/prereq/defaults/main.yml
+++ b/roles/prereq/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+secure_path:
+  RedHat: '/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'
+  Suse: '/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin'

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -60,10 +60,10 @@
 
 - name: Add /usr/local/bin to sudo secure_path
   lineinfile:
-    line: 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin'
+    line: 'Defaults    secure_path = {{ secure_path[ansible_os_family] }}'
     regexp: "Defaults(\\s)*secure_path(\\s)*="
     state: present
     insertafter: EOF
     path: /etc/sudoers
     validate: 'visudo -cf %s'
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family in [ "RedHat", "Suse" ]


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
Expanded the prereq role's secure_path task with support for Suse.
Added a default var (secure_path) for that task too, with separate values for RedHat and Suse.
(Didn't want to override Suse's default path order, nor RedHat's, I'm sure someone smarter than me decided on those orders for a reason)
Tested both site and reset.yml.
(Everything worked perfectly for openSUSE Leap 15.5 and SLES 15 SP5)


## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
