### PR TITLE
Add option for custom registries / mirrors

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -81,3 +81,43 @@ proxmox_lxc_ct_ids:
   - 202
   - 203
   - 204
+
+# Only enable this if you have set up your own container registry to act as a mirror / pull-through cache
+# (harbor / nexus / docker's official registry / etc).
+# Can be beneficial for larger dev/test environments (for example if you're getting rate limited by docker hub),
+# or air-gapped environments where your nodes don't have internet access after the initial setup
+# (which is still needed for downloading the k3s binary and such).
+# k3s's documentation about private registries here: https://docs.k3s.io/installation/private-registry
+custom_registries: false
+# The registries can be authenticated or anonymous, depending on your registry server configuration.
+# If they allow anonymous access, simply remove the following bit from custom_registries_yaml
+#   configs:
+#     "registry.domain.com":
+#       auth:
+#         username: yourusername
+#         password: yourpassword
+# The following is an example that pulls all images used in this playbook through your private registries.
+# It also allows you to pull your own images from your private registry, without having to use imagePullSecrets
+# in your deployments.
+# If all you need is your own images and you don't care about caching the docker/quay/ghcr.io images,
+# you can just remove those from the mirrors: section.
+custom_registries_yaml: |
+  mirrors:
+    docker.io:
+      endpoint:
+        - "https://registry.domain.com/v2/dockerhub"
+    quay.io:
+      endpoint:
+        - "https://registry.domain.com/v2/quayio"
+    ghcr.io:
+      endpoint:
+        - "https://registry.domain.com/v2/ghcrio"
+    registry.domain.com:
+      endpoint:
+        - "https://registry.domain.com"
+
+  configs:
+    "registry.domain.com":
+      auth:
+        username: yourusername
+        password: yourpassword

--- a/roles/k3s_custom_registries/defaults/main.yml
+++ b/roles/k3s_custom_registries/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Indicates whether custom registries for k3s should be configured
+# Possible values:
+#   - present
+#   - absent
+state: present

--- a/roles/k3s_custom_registries/tasks/main.yml
+++ b/roles/k3s_custom_registries/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Create directory /etc/rancher/k3s
+  file:
+    path: "/etc/{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - rancher
+    - rancher/k3s
+
+- name: Insert registries into /etc/rancher/k3s/registries.yaml
+  blockinfile:
+    path: /etc/rancher/k3s/registries.yaml
+    block: "{{ custom_registries_yaml }}"
+    mode: '0600'
+    create: true

--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,9 @@
       become: true
     - role: raspberrypi
       become: true
+    - role: k3s_custom_registries
+      become: true
+      when: custom_registries
 
 - name: Setup k3s servers
   hosts: master


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
Added support for custom, private registries in k3s, according to [their documentation.](https://docs.k3s.io/installation/private-registry)
(Got inspired after getting rate limited by docker hub at work..)

As I've documented in the `sample/all.yml` comments, it could be useful if you're getting rate limited (for example by running your CI/CD jobs over and over in your cluster), or you're in an air-gapped environment where you don't have Internet access after the initial setup, or if you're bandwidth limited.
If you've set up a private registry (for example using Sonatype Nexus, or Docker's Registry image, or Harbor),
to act as a "pull-through cache" as docker calls it, you can specify and override those docker.io / quay.io / ghcr.io endpoints with your own in `/etc/rancher/k3s/registries.yaml`.

Doing that also allows you to use your actual private registry, the one that stores **your** images, without having to store registry credentials in a secret and using `imagePullSecrets` in your deployments.

Of course you don't **_have to_** cache / proxy the docker.io / quay.io / ghcr.io images if you don't want / need to, you can just use this to add **only** your private registry.

I've tested both the caching and the **private** registry parts using my Harbor instance, works flawlessly.

Edit: I didn't add an "undo part" for the reset playbook, because the `/etc/rancher/k3s` dir gets cleaned up already.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
