### PR TITLE
Add option for install behind http_proxy

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -121,3 +121,9 @@ custom_registries_yaml: |
       auth:
         username: yourusername
         password: yourpassword
+
+# Only enable and configure these if you access the internet through a proxy
+http_proxy_configure: false
+http_proxy: "http://proxy.domain.local:3128"
+https_proxy: "http://proxy.domain.local:3128"
+no_proxy: "*.domain.local,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -123,7 +123,7 @@ custom_registries_yaml: |
         password: yourpassword
 
 # Only enable and configure these if you access the internet through a proxy
-http_proxy_configure: false
-http_proxy: "http://proxy.domain.local:3128"
-https_proxy: "http://proxy.domain.local:3128"
-no_proxy: "*.domain.local,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+# proxy_env:
+#   HTTP_PROXY: "http://proxy.domain.local:3128"
+#   HTTPS_PROXY: "http://proxy.domain.local:3128"
+#   NO_PROXY: "*.domain.local,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"

--- a/roles/k3s_agent/tasks/http_proxy.yml
+++ b/roles/k3s_agent/tasks/http_proxy.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Create k3s.service.d directory
+  file:
+    path: '{{ systemd_dir }}/k3s.service.d'
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+
+- name: Copy K3s http_proxy conf file
+  template:
+    src: "http_proxy.conf.j2"
+    dest: "{{ systemd_dir }}/k3s.service.d/http_proxy.conf"
+    owner: root
+    group: root
+    mode: '0755'

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Deploy K3s http_proxy conf
+  include_tasks: http_proxy.yml
+  when: http_proxy_configure | default(false)
+
 - name: Copy K3s service file
   template:
     src: "k3s.service.j2"

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Deploy K3s http_proxy conf
   include_tasks: http_proxy.yml
-  when: http_proxy_configure | default(false)
+  when: proxy_env is defined
 
 - name: Copy K3s service file
   template:

--- a/roles/k3s_agent/templates/http_proxy.conf.j2
+++ b/roles/k3s_agent/templates/http_proxy.conf.j2
@@ -1,4 +1,4 @@
 [Service]
-Environment=HTTP_PROXY={{ http_proxy }}
-Environment=HTTPS_PROXY={{ https_proxy }}
-Environment=NO_PROXY={{ no_proxy }}
+Environment=HTTP_PROXY={{ proxy_env.HTTP_PROXY }}
+Environment=HTTPS_PROXY={{ proxy_env.HTTPS_PROXY }}
+Environment=NO_PROXY={{ proxy_env.NO_PROXY }}

--- a/roles/k3s_agent/templates/http_proxy.conf.j2
+++ b/roles/k3s_agent/templates/http_proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment=HTTP_PROXY={{ http_proxy }}
+Environment=HTTPS_PROXY={{ https_proxy }}
+Environment=NO_PROXY={{ no_proxy }}

--- a/roles/k3s_server/tasks/http_proxy.yml
+++ b/roles/k3s_server/tasks/http_proxy.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Create k3s.service.d directory
+  file:
+    path: '{{ systemd_dir }}/k3s.service.d'
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+
+- name: Copy K3s http_proxy conf file
+  template:
+    src: "http_proxy.conf.j2"
+    dest: "{{ systemd_dir }}/k3s.service.d/http_proxy.conf"
+    owner: root
+    group: root
+    mode: '0755'

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Deploy K3s http_proxy conf
   include_tasks: http_proxy.yml
-  when: http_proxy_configure | default(false)
+  when: proxy_env is defined
 
 - name: Deploy vip manifest
   include_tasks: vip.yml

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -12,6 +12,10 @@
   failed_when: false
   changed_when: false
 
+- name: Deploy K3s http_proxy conf
+  include_tasks: http_proxy.yml
+  when: http_proxy_configure | default(false)
+
 - name: Deploy vip manifest
   include_tasks: vip.yml
 

--- a/roles/k3s_server/templates/http_proxy.conf.j2
+++ b/roles/k3s_server/templates/http_proxy.conf.j2
@@ -1,4 +1,4 @@
 [Service]
-Environment=HTTP_PROXY={{ http_proxy }}
-Environment=HTTPS_PROXY={{ https_proxy }}
-Environment=NO_PROXY={{ no_proxy }}
+Environment=HTTP_PROXY={{ proxy_env.HTTP_PROXY }}
+Environment=HTTPS_PROXY={{ proxy_env.HTTPS_PROXY }}
+Environment=NO_PROXY={{ proxy_env.NO_PROXY }}

--- a/roles/k3s_server/templates/http_proxy.conf.j2
+++ b/roles/k3s_server/templates/http_proxy.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+Environment=HTTP_PROXY={{ http_proxy }}
+Environment=HTTPS_PROXY={{ https_proxy }}
+Environment=NO_PROXY={{ no_proxy }}

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -53,7 +53,7 @@
   with_items:
     - "{{ systemd_dir }}/k3s.service.d"
     - "{{ systemd_dir }}/k3s-node.service.d"
-  when: http_proxy_configure | default(false)
+  when: proxy_env is defined
 
 - name: Reload daemon_reload
   systemd:

--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -46,6 +46,15 @@
     - /var/lib/rancher/
     - /var/lib/cni/
 
+- name: Remove K3s http_proxy files
+  file:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ systemd_dir }}/k3s.service.d"
+    - "{{ systemd_dir }}/k3s-node.service.d"
+  when: http_proxy_configure | default(false)
+
 - name: Reload daemon_reload
   systemd:
     daemon_reload: yes

--- a/site.yml
+++ b/site.yml
@@ -3,6 +3,10 @@
   hosts: proxmox
   gather_facts: true
   become: yes
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
   roles:
     - role: proxmox_lxc
       when: proxmox_lxc_configure
@@ -10,6 +14,10 @@
 - name: Prepare k3s nodes
   hosts: k3s_cluster
   gather_facts: yes
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
   roles:
     - role: lxc
       become: true
@@ -26,18 +34,30 @@
 
 - name: Setup k3s servers
   hosts: master
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
   roles:
     - role: k3s_server
       become: true
 
 - name: Setup k3s agents
   hosts: node
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
   roles:
     - role: k3s_agent
       become: true
 
 - name: Configure k3s cluster
   hosts: master
+  environment:
+    HTTP_PROXY: "{{ http_proxy | default('') }}"
+    HTTPS_PROXY: "{{ https_proxy | default('') }}"
+    NO_PROXY: "{{ no_proxy | default('') }}"
   roles:
     - role: k3s_server_post
       become: true

--- a/site.yml
+++ b/site.yml
@@ -3,10 +3,7 @@
   hosts: proxmox
   gather_facts: true
   become: yes
-  environment:
-    HTTP_PROXY: "{{ http_proxy | default('') }}"
-    HTTPS_PROXY: "{{ https_proxy | default('') }}"
-    NO_PROXY: "{{ no_proxy | default('') }}"
+  environment: "{{ proxy_env | default({}) }}"
   roles:
     - role: proxmox_lxc
       when: proxmox_lxc_configure
@@ -14,10 +11,7 @@
 - name: Prepare k3s nodes
   hosts: k3s_cluster
   gather_facts: yes
-  environment:
-    HTTP_PROXY: "{{ http_proxy | default('') }}"
-    HTTPS_PROXY: "{{ https_proxy | default('') }}"
-    NO_PROXY: "{{ no_proxy | default('') }}"
+  environment: "{{ proxy_env | default({}) }}"
   roles:
     - role: lxc
       become: true
@@ -34,30 +28,21 @@
 
 - name: Setup k3s servers
   hosts: master
-  environment:
-    HTTP_PROXY: "{{ http_proxy | default('') }}"
-    HTTPS_PROXY: "{{ https_proxy | default('') }}"
-    NO_PROXY: "{{ no_proxy | default('') }}"
+  environment: "{{ proxy_env | default({}) }}"
   roles:
     - role: k3s_server
       become: true
 
 - name: Setup k3s agents
   hosts: node
-  environment:
-    HTTP_PROXY: "{{ http_proxy | default('') }}"
-    HTTPS_PROXY: "{{ https_proxy | default('') }}"
-    NO_PROXY: "{{ no_proxy | default('') }}"
+  environment: "{{ proxy_env | default({}) }}"
   roles:
     - role: k3s_agent
       become: true
 
 - name: Configure k3s cluster
   hosts: master
-  environment:
-    HTTP_PROXY: "{{ http_proxy | default('') }}"
-    HTTPS_PROXY: "{{ https_proxy | default('') }}"
-    NO_PROXY: "{{ no_proxy | default('') }}"
+  environment: "{{ proxy_env | default({}) }}"
   roles:
     - role: k3s_server_post
       become: true


### PR DESCRIPTION
# Proposed Changes
Added the option to install from behind an http proxy.

If configured (false by default), it puts your `http_proxy` + `https_proxy` + `no_proxy` env vars into a `k3s(-agent).service.d/http_proxy.conf` file, before anything gets installed.
This way k3s can access the internet for images etc through the proxy.

Also added env vars to the playbooks, defaulted to '', so ansible can still download the binaries and manifests even if you're behind a proxy.

In the reset main.yml I thought I'd add a conditional task.
So it doesn't try to remove the http_proxy files and errors out when you don't have them enabled/installed.

(I've ran and re-ran the checks a bunch of times on my fork, not sure what's up with the hosted runners.
The majority of the time it failed with the gurumeditation state error and when it _did_ go past that, it couldn't resolve DNS.
I've ran this both with http_proxy enabled and disabled, installed fine in both environments.)

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
