### PR TITLE
Add PXE boot support to k3s_agent role

### DIFF
--- a/roles/k3s_agent/tasks/http_proxy.yml
+++ b/roles/k3s_agent/tasks/http_proxy.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create k3s-node.service.d directory
   file:
     path: '{{ systemd_dir }}/k3s-node.service.d'

--- a/roles/k3s_agent/tasks/http_proxy.yml
+++ b/roles/k3s_agent/tasks/http_proxy.yml
@@ -6,7 +6,7 @@
     owner: root
     group: root
     mode: '0755'
-
+  when: proxy_env is defined
 
 - name: Copy K3s http_proxy conf file
   template:
@@ -15,3 +15,4 @@
     owner: root
     group: root
     mode: '0755'
+  when: proxy_env is defined

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Check if system is PXE-booted
+  command: cat /proc/cmdline
+  register: boot_cmdline
+  changed_when: false
+
+- name: Set fact for PXE-booted system
+  set_fact:
+    is_pxe_booted: "{{ 'root=/dev/nfs' in boot_cmdline.stdout }}"
+  when: boot_cmdline is defined
 
 - name: Deploy K3s http_proxy conf
   include_tasks: http_proxy.yml

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -1,28 +1,35 @@
 ---
-- name: Check if system is PXE-booted
-  command: cat /proc/cmdline
-  register: boot_cmdline
-  changed_when: false
+- name: Check for PXE-booted system
+  block:
+    - name: Check if system is PXE-booted
+      ansible.builtin.command:
+        cmd: cat /proc/cmdline
+      register: boot_cmdline
+      changed_when: false
+      check_mode: false
 
-- name: Set fact for PXE-booted system
-  set_fact:
-    is_pxe_booted: "{{ 'root=/dev/nfs' in boot_cmdline.stdout }}"
-  when: boot_cmdline is defined
+    - name: Set fact for PXE-booted system
+      ansible.builtin.set_fact:
+        is_pxe_booted: "{{ 'root=/dev/nfs' in boot_cmdline.stdout }}"
+      when: boot_cmdline.stdout is defined
+
+    - name: Include http_proxy configuration tasks
+      ansible.builtin.include_tasks: http_proxy.yml
 
 - name: Deploy K3s http_proxy conf
   include_tasks: http_proxy.yml
   when: proxy_env is defined
 
-- name: Copy K3s service file
-  template:
+- name: Configure the k3s service
+  ansible.builtin.template:
     src: "k3s.service.j2"
     dest: "{{ systemd_dir }}/k3s-node.service"
     owner: root
     group: root
-    mode: 0755
+    mode: '0755'
 
-- name: Enable and check K3s service
-  systemd:
+- name: Manage k3s service
+  ansible.builtin.systemd:
     name: k3s-node
     daemon_reload: true
     state: restarted

--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -7,11 +7,14 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s agent --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 --token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} {{ extra_agent_args | default("") }}
+# Conditional snapshotter based on PXE boot status
+ExecStart=/usr/local/bin/k3s agent \
+  --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 \
+  {% if is_pxe_booted | default(false) %}--snapshotter native \
+  {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} \
+  {{ extra_agent_args | default("") }}
 KillMode=process
 Delegate=yes
-# Having non-zero Limit*s causes performance problems due to accounting overhead
-# in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNOFILE=1048576
 LimitNPROC=infinity
 LimitCORE=infinity


### PR DESCRIPTION
Huge fan of this project, thanks for creating and maintaining it!

I'm happy to submit another PR to implement PXE boot support for the server role, 
but wanted to make sure there was interest in the existing work I've done first.

# Proposed Changes

- Introduced enhancements to the `k3s_agent` role to address a specific issue encountered while setting up a Raspberry Pi 4 for PXE booting. This includes adding checks for PXE-boot conditions and modifying the `k3s.service.j2` template to dynamically set the `native` snapshotter, resolving issues related to "overlayfs" snapshotter incompatibilities in such setups.
- Improved overall maintainability and readability of the `k3s_agent` role by adopting idiomatic Ansible practices. This involved restructuring tasks into logical blocks, implementing conditional task execution, and transitioning to Ansible builtin modules for future-proofing and better compatibility.

## Context

While adding a new Raspberry Pi 4 to the cluster and setting it up to PXE boot from a Synology NAS, I encountered an error related to the "overlayfs" snapshotter. After some investigation, I realized that specifying the "native" snapshotter could resolve this. These changes are intended to help others who might face the same issue, streamlining their setup process and enhancing the usability of this project.

## Checklist

- [x] Tested on two Raspberry Pi 4Bs: one configured to boot from an 
  external SSD and the other set up for network booting (PXE) from a NAS. 
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀