### PR TITLE
fix(ci): only run CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: "CI"
 on:
   pull_request:
     types:
+      - opened
       - synchronize
     paths-ignore:
       - '**/README.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@
 name: "CI"
 on:
   pull_request:
-  push:
-    branches:
-      - master
     paths-ignore:
       - '**/README.md'
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 name: "CI"
 on:
   pull_request:
+    types:
+      - synchronize
     paths-ignore:
       - '**/README.md'
 jobs:


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- this closes #429 
- there's no point of running CI after a merge since we don't deploy
- this causes builds to queue up for no reason
- this should disable it

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
