### PR TITLE
fetch kubeconfig from master after deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env/
 *.log
 ansible.cfg
+kubeconfig

--- a/site.yml
+++ b/site.yml
@@ -46,3 +46,14 @@
   roles:
     - role: k3s_server_post
       become: true
+
+- name: Storing kubeconfig in the playbook directory
+  hosts: master
+  environment: "{{ proxy_env | default({}) }}"
+  tasks:
+    - name: Copying kubeconfig from {{ hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname'] }}
+      ansible.builtin.fetch:
+        src: "{{ ansible_user_dir }}/.kube/config"
+        dest: ./kubeconfig
+        flat: true
+      when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']


### PR DESCRIPTION
# Proposed Changes

This PR adds a final step to the site.yml playbook, downloading the ~/.kube/config file from the first master to kubekonfig in the playbook directory.
This way you can `export KUBECONFIG=${PWD}/kubeconfig`, and deploy, reset, deploy, reset, deploy... and never worry about having the right kubeconfig.
I deliberately placed this task in the playbook, it shouldn't be part of a (reusable) role. 

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
