### PR TITLE
fix(cilium): k3s has an API server proxy at `127.0.0.1:6444`

### DIFF
--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -170,8 +170,8 @@
         {% if cilium_mode == "native" or (cilium_bgp and cilium_exportPodCIDR != 'false') %}
         --helm-set ipv4NativeRoutingCIDR={{ cluster_cidr }}
         {% endif %}
-        --helm-set k8sServiceHost={{ apiserver_endpoint }}
-        --helm-set k8sServicePort="6443"
+        --helm-set k8sServiceHost="127.0.0.1"
+        --helm-set k8sServicePort="6444"
         --helm-set routingMode={{ cilium_mode | default("native") }}
         --helm-set autoDirectNodeRoutes={{ "true" if cilium_mode == "native" else "false" }}
         --helm-set kubeProxyReplacement={{ kube_proxy_replacement | default("true") }}


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

There is no need to use kube-vip LB for this Cilium config, k3s has an API server proxy listening in `127.0.0.1:6444` on all nodes in the cluster. I run with this setup in the https://github.com/onedr0p/cluster-template so just sharing some knowledge to here.

## Checklist

- [x] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [x] 🚀
