### PR TITLE
Added pre_task to verify minimum Ansible version

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,11 +1,12 @@
 ---
-- hosts: all
+- name: Pre tasks
+  hosts: all
   pre_tasks:
-    - name: Verify Ansible is version 2.11 or above.
+    - name: Verify Ansible is version 2.11 or above. (If this fails you may need to update Ansible)
       assert:
         that: "ansible_version.full is version_compare('2.11', '>=')"
         msg: >
-          "Your version of Ansible is out of date. Please follow this link to install the latest version: https://docs.technotim.live/posts/ansible-automation/#installing-the-latest-version-of-ansible"
+          "Ansible is out of date. See here for more info: https://docs.technotim.live/posts/ansible-automation/"
 
 - name: Prepare Proxmox cluster
   hosts: proxmox

--- a/site.yml
+++ b/site.yml
@@ -1,4 +1,12 @@
 ---
+- hosts: all
+  pre_tasks:
+    - name: Verify Ansible is version 2.11 or above.
+      assert:
+        that: "ansible_version.full is version_compare('2.11', '>=')"
+        msg: >
+          "Your version of Ansible is out of date. Please follow this link to install the latest version: https://docs.technotim.live/posts/ansible-automation/#installing-the-latest-version-of-ansible"
+
 - name: Prepare Proxmox cluster
   hosts: proxmox
   gather_facts: true


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
Added a pre_task to site.yml to verify the minimum version of Ansible (2.11). 

Note: playbook syntax requires a non-empty "hosts" line, but the version check happens in the local machine (not the hosts in the host.ini).
-
-
-

## Checklist

- [X] Tested locally
- [X] Ran `site.yml` playbook
- [X] Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [X] Ran pre-commit install at least once before committing
- [X] 🚀
