### PR TITLE
Fix cgroups cmdline path

### DIFF
--- a/roles/raspberrypi/tasks/setup/Raspbian.yml
+++ b/roles/raspberrypi/tasks/setup/Raspbian.yml
@@ -1,7 +1,7 @@
 ---
 - name: Activating cgroup support
   lineinfile:
-    path: /boot/cmdline.txt
+    path: /boot/firmware/cmdline.txt
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true

--- a/roles/raspberrypi/tasks/setup/Raspbian.yml
+++ b/roles/raspberrypi/tasks/setup/Raspbian.yml
@@ -1,7 +1,17 @@
 ---
+- name: Test for cmdline path
+  command: grep -E "console=|rootfstype" /boot/cmdline.txt
+  register: boot_cmdline_path
+  failed_when: false
+  changed_when: false
+
+- name: Set path to cmdline based on test
+  set_fact:
+    cmdline_path: "{{ (boot_cmdline_path.rc == 0) | ternary('/boot/cmdline.txt', '/boot/firmware/cmdline.txt') }}"
+
 - name: Activating cgroup support
   lineinfile:
-    path: /boot/firmware/cmdline.txt
+    path: "{{ cmdline_path }}"
     regexp: '^((?!.*\bcgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory\b).*)$'
     line: '\1 cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory'
     backrefs: true

--- a/roles/raspberrypi/tasks/setup/Raspbian.yml
+++ b/roles/raspberrypi/tasks/setup/Raspbian.yml
@@ -5,9 +5,18 @@
   failed_when: false
   changed_when: false
 
-- name: Set cmdline path based on Debian version and boot_cmdline_path result
+- name: Set cmdline path based on Debian version and command result
   set_fact:
-    cmdline_path: "{{ (boot_cmdline_path.rc == 0 and ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_version'] is version('bookworm', '<')) | ternary('/boot/cmdline.txt', '/boot/firmware/cmdline.txt') }}"
+    cmdline_path: >-
+      {{
+        (
+          boot_cmdline_path.rc == 0 and
+          ansible_facts.lsb.description | default('') is match('Debian.*(?!(bookworm|sid))')
+        ) | ternary(
+          '/boot/cmdline.txt',
+          '/boot/firmware/cmdline.txt'
+        )
+      }}
 
 - name: Activating cgroup support
   lineinfile:

--- a/roles/raspberrypi/tasks/setup/Raspbian.yml
+++ b/roles/raspberrypi/tasks/setup/Raspbian.yml
@@ -5,9 +5,9 @@
   failed_when: false
   changed_when: false
 
-- name: Set path to cmdline based on test
+- name: Set cmdline path based on Debian version and boot_cmdline_path result
   set_fact:
-    cmdline_path: "{{ (boot_cmdline_path.rc == 0) | ternary('/boot/cmdline.txt', '/boot/firmware/cmdline.txt') }}"
+    cmdline_path: "{{ (boot_cmdline_path.rc == 0 and ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_version'] is version('bookworm', '<')) | ternary('/boot/cmdline.txt', '/boot/firmware/cmdline.txt') }}"
 
 - name: Activating cgroup support
   lineinfile:

--- a/roles/raspberrypi/tasks/setup/Raspbian.yml
+++ b/roles/raspberrypi/tasks/setup/Raspbian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Test for cmdline path
-  command: grep -E "console=|rootfstype" /boot/cmdline.txt
+  stat:
+    path: /boot/firmware/cmdline.txt
   register: boot_cmdline_path
   failed_when: false
   changed_when: false
@@ -10,11 +11,11 @@
     cmdline_path: >-
       {{
         (
-          boot_cmdline_path.rc == 0 and
+          boot_cmdline_path.stat.exists and
           ansible_facts.lsb.description | default('') is match('Debian.*(?!(bookworm|sid))')
         ) | ternary(
-          '/boot/cmdline.txt',
-          '/boot/firmware/cmdline.txt'
+          '/boot/firmware/cmdline.txt',
+          '/boot/cmdline.txt'
         )
       }}
 


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

When replacing a node, I noticed that the cgroups task has an old path. Old Raspbian had `/boot/cmdline.txt`, but that file has been moved to `/boot/firmware/cmdline.txt`. Upon updating that path, configuration completed successfully and k3s service started without error. When I originally built the cluster, I made that change manually. Replacing a node and using the playbook exposed this issue.

## References

- https://forums.raspberrypi.com/viewtopic.php?t=365886
- https://forums.raspberrypi.com/viewtopic.php?p=2186916

## Checklist

- [X] Create a test for the path: if /boot/cmdline.txt exists and has the content we want, make the change there. If not, move on to /boot/firmware/cmdline.txt
- [X] Tested locally
- [X] Ran `site.yml` playbook
- [ ] N/A (not used in reset.yml) Ran `reset.yml` playbook
- [X] Did not add any unnecessary changes
- [X] Ran pre-commit install at least once before committing
- [X] 🚀
