### PR TITLE
Cilium Install - Ensure KUBECONFIG points to install users home directory

### DIFF
--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -185,7 +185,7 @@
         --helm-set bpf.loadBalancer.mode={{ bpf_lb_mode | default("hybrid") }}
         {% endif %}
       environment:
-        KUBECONFIG: /home/{{ ansible_user }}/.kube/config
+        KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
       register: cilium_install_result
       changed_when: cilium_install_result.rc == 0
       when: cilium_installed.rc != 0 or cilium_needs_update


### PR DESCRIPTION
This PR addresses the issue if the install user's home directory is not in `/home/username`. The `Copy config file to user home directory` task copies `/etc/rancher/k3s/k3s.yaml` to `"{{ ansible_user_dir }}/.kube/config"`

Without this change, when installing Cilium by a non-standard user, it will fail to set the `KUBECONFIG` correctly and the cilium installer will fail to fetch the k8s/k3s version with an error as described in https://github.com/techno-tim/k3s-ansible/issues/446.

# Proposed Changes
- This ensures the `KUBECONFIG` environment variable points to the user's directory and does not assume it is in `/home/username/.kube/config`

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
