### PR TITLE
Support defining a custom reboot command

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -160,6 +160,10 @@ custom_registries_yaml: |
         username: yourusername
         password: yourpassword
 
+# On some distros like Diet Pi, there is no dbus installed. dbus required by the default reboot command.
+# Uncomment if you need a custom reboot command
+# custom_reboot_command: /usr/sbin/shutdown -r now
+
 # Only enable and configure these if you access the internet through a proxy
 # proxy_env:
 #   HTTP_PROXY: "http://proxy.domain.local:3128"

--- a/reboot.yml
+++ b/reboot.yml
@@ -6,4 +6,5 @@
     - name: Reboot the nodes (and Wait upto 5 mins max)
       become: true
       reboot:
+        reboot_command: "{{ custom_reboot_command | default(omit) }}"
         reboot_timeout: 300

--- a/reset.yml
+++ b/reset.yml
@@ -12,6 +12,7 @@
     - name: Reboot and wait for node to come back up
       become: true
       reboot:
+        reboot_command: "{{ custom_reboot_command | default(omit) }}"
         reboot_timeout: 3600
 
 - name: Revert changes to Proxmox cluster

--- a/roles/lxc/handlers/main.yml
+++ b/roles/lxc/handlers/main.yml
@@ -2,4 +2,5 @@
 - name: Reboot server
   become: true
   reboot:
+    reboot_command: "{{ custom_reboot_command | default(omit) }}"
   listen: reboot server

--- a/roles/raspberrypi/handlers/main.yml
+++ b/roles/raspberrypi/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
 - name: Reboot
   reboot:
+    reboot_command: "{{ custom_reboot_command | default(omit) }}"
   listen: reboot


### PR DESCRIPTION
# Proposed Changes

This change adds an optional `custom_reboot_command`. On Diet Pi, there is no dbus installed. See [Diet Pi Release Notes](https://dietpi.com/docs/releases/v8_22/#bug-fixes).

> DietPi ships without dbus and with logind masked by default, as we do not see their features being used on a typical DietPi system. Instead, dbus is installed and logind unmasked on demand on certain software installs or when chosen via dietpi.txt. However, the newer systemd version since Bookworm attempts dbus > logind communication in any case when calling poweroff/reboot/halt, despite no wall message being sent, e.g. to handle shutdown inhibitors (like open SSH session being able to prevent shutdown), and throws errors if either dbus is not reachable or logind not running. Until in case dbus or logind are further tied into common system commands or features, we solved the issue by creating shell functions for poweroff/reboot/halt which call the respective systemd target directly to bypass logind (and hence dbus), but fall back to the original commands, depending on given command-line parameters.

 If  `custom_reboot_command` is defined, the `reboot_command` parameter will be passed to the `ansible.builtin.reboot` module. If  `custom_reboot_command` is not defined, then  `reboot_command` is omitted and the default behavior occurs.

- Add commented out variable to `sample/group_vars/all.yml` with comments
- Add `reboot_command: "{{ custom_reboot_command | default(omit) }}"` to each reboot module usage.

Fixes one problem in https://github.com/techno-tim/k3s-ansible/issues/463

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
