### PR TITLE
Update Kube Config instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,22 @@ ansible-playbook reset.yml -i inventory/my-cluster/hosts.ini
 To copy your `kube config` locally so that you can access your **Kubernetes** cluster run:
 
 ```bash
-scp debian@master_ip:~/.kube/config ~/.kube/config
+scp debian@master_ip:/etc/rancher/k3s/k3s.yaml ~/.kube/config
 ```
+If you get file Permission denied, go into the node and temporarly run:
+```bash
+sudo chmod 777 /etc/rancher/k3s/k3s.yaml
+```
+Then copy with the scp command and reset the permissions back to:
+```bash
+sudo chmod 600 /etc/rancher/k3s/k3s.yaml
+```
+
+You'll then want to modify the config to point to master IP by running:
+```bash
+sudo nano ~/.kube/config
+```
+Then change `server: https://127.0.0.1:6443` to match your master IP: `server: https://192.168.1.222:6443`
 
 ### 🔨 Testing your cluster
 


### PR DESCRIPTION
# Proposed Changes
Instructions were unclear on how to have the Kube config copied. As a noob, I spent a considerable amount of time figuring out where the config file was and why the proposed `scp debian@master_ip:~/.kube/config ~/.kube/config` was giving me no such file error. So, I thought I would help the next home labber by including these updated instructions.

- Updated to include the new location for kube config
- Added possible errors and how to overcome them
- Steps to do after copying the config

I acknowledge that I might be an edge case where the .kube/config file was not deployed in the proper place, but in case this is the new design the PR is here to help out!

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [x] 🚀

Since it is just documentation I will not rerun the site.yml as it is picky!