### PR TITLE
fix(molecule): Disable ipv6 test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         scenario:
           - default
-          - ipv6
+          # - ipv6
           - single_node
           - calico
           - cilium


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- disabling ipv6 tests per https://github.com/techno-tim/k3s-ansible/issues/475
- would love to enable them again in the future

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
