### PR TITLE
Allow IP range for `cilium_bgp_lb_cidr`

### DIFF
--- a/roles/k3s_server_post/templates/cilium.crs.j2
+++ b/roles/k3s_server_post/templates/cilium.crs.j2
@@ -25,5 +25,10 @@ kind: CiliumLoadBalancerIPPool
 metadata:
   name: "01-lb-pool"
 spec:
-  cidrs:
-  - cidr: "{{ cilium_bgp_lb_cidr }}"
+  blocks:
+{% if "/" in cilium_bgp_lb_cidr %}
+  - cidr: {{ cilium_bgp_lb_cidr }}
+{% else %}
+  - start: {{ cilium_bgp_lb_cidr.split('-')[0] }}
+    stop: {{ cilium_bgp_lb_cidr.split('-')[1] }}
+{% endif %}


### PR DESCRIPTION
# Proposed Changes

The current implementation  of `cilium_bgp_lb_cidr` does not allow allow for an IP range to be provided.
This PR uses the same syntax as `kube_vip_lb_ip_range` and `metal_lb_ip_range` to achieve the same.

## Checklist

- [ ] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [ ] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [ ] 🚀
