### PR TITLE
chore(core): update k3s to v1.30.0+k3s1

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.29.2+k3s1
+k3s_version: v1.30.0+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system


### PR DESCRIPTION
k3s has recently released their first release based upon Kubernetes 1.30 so let's upgrade to that.

https://github.com/k3s-io/k3s/releases
https://github.com/k3s-io/k3s/releases/tag/v1.30.0%2Bk3s1 https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md#changelog-since-v1290

Fixes #506 🚀 :shipit: 