### PR TITLE
fixed broken when statement for metallb optional tasks

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -29,7 +29,7 @@
 - name: Deploy metallb manifest
   include_tasks: metallb.yml
   tags: metallb
-  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined)
+  when: kube_vip_lb_ip_range is not defined and (cilium_bgp is not defined or cilium_iface is not defined)
 
 - name: Deploy kube-vip manifest
   include_tasks: kube-vip.yml

--- a/roles/k3s_server_post/tasks/main.yml
+++ b/roles/k3s_server_post/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Deploy metallb pool
   include_tasks: metallb.yml
   tags: metallb
-  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined)
+  when: kube_vip_lb_ip_range is not defined and (cilium_bgp is not defined or cilium_iface is not defined)
 
 - name: Remove tmp directory used for manifests
   file:


### PR DESCRIPTION
# Proposed Changes

Adjusted the when: for calling metallb.yml in both k3s_server and k3s_server_post roles as to not fail in undefined var checks.

## Checklist

- [x] Tested locally
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [ ] 🚀

