### PR TITLE
k3s_server: add kube_vip_arp parameter

### DIFF
--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -4,6 +4,9 @@
 # will determine the right interface automatically at runtime.
 kube_vip_iface: null
 
+# Enables ARP broadcasts from Leader
+kube_vip_arp: true
+
 # Name of the master group
 group_name_master: master
 

--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -27,7 +27,7 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "true"
+          value: "{{ 'true' if kube_vip_arp | bool else 'false' }}"
         - name: port
           value: "6443"
 {% if kube_vip_iface %}


### PR DESCRIPTION
With the kube_vip_arp parameter it is possible to set or unset the vip_arp environment variable of the kube-vip-ds daemonset. The value of the kube_vip_arp is true by default to not change the existing default.