### PR TITLE
k3s_server: add kube-vip BGP support

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -34,6 +34,18 @@ cilium_bgp_peer_asn: "64512"
 cilium_bgp_peer_address: "192.168.30.1"
 cilium_bgp_lb_cidr: "192.168.31.0/24"   # cidr for cilium loadbalancer ipam
 
+# enable kube-vip ARP broadcasts
+kube_vip_arp: true
+
+# enable kube-vip BGP peering
+kube_vip_bgp: false
+
+# bgp parameters for kube-vip
+kube_vip_bgp_routerid: "127.0.0.1"  # Defines the router ID for the BGP server
+kube_vip_bgp_as: "64513"  # Defines the AS for the BGP server
+kube_vip_bgp_peeraddress: "192.168.30.1"  # Defines the address for the BGP peer
+kube_vip_bgp_peeras: "64512"  # Defines the AS for the BGP peer
+
 # apiserver_endpoint is virtual ip-address which will be configured on each master
 apiserver_endpoint: "192.168.30.222"
 

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -8,6 +8,12 @@ kube_vip_iface: ~
 kube_vip_cloud_provider_tag_version: main
 kube_vip_tag_version: v0.7.2
 
+kube_vip_bgp: false
+kube_vip_bgp_routerid: "127.0.0.1"
+kube_vip_bgp_as: "64513"
+kube_vip_bgp_peeraddress: "192.168.30.1"
+kube_vip_bgp_peeras: "64512"
+
 metal_lb_controller_tag_version: v0.14.3
 metal_lb_speaker_tag_version: v0.14.3
 metal_lb_type: native

--- a/roles/k3s_server/meta/main.yml
+++ b/roles/k3s_server/meta/main.yml
@@ -27,9 +27,30 @@ argument_specs:
         default: master
 
       kube_vip_arp:
-        description: Enables ARP broadcasts from Leader
+        description: Enables kube-vip ARP broadcasts
         default: true
         type: bool
+
+      kube_vip_bgp:
+        description: Enables kube-vip BGP peering
+        default: false
+        type: bool
+
+      kube_vip_bgp_routerid:
+        description: Defines the router ID for the kube-vip BGP server
+        default: "127.0.0.1"
+
+      kube_vip_bgp_as:
+        description: Defines the AS for the kube-vip BGP server
+        default: "64513"
+
+      kube_vip_bgp_peeraddress:
+        description: Defines the address for the kube-vip BGP peer
+        default: "192.168.30.1"
+
+      kube_vip_bgp_peeras:
+        description: Defines the AS for the kube-vip BGP peer
+        default: "64512"
 
       kube_vip_iface:
         description:

--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -27,7 +27,9 @@ spec:
         - manager
         env:
         - name: vip_arp
-          value: "{{ 'true' if kube_vip_arp | bool else 'false' }}"
+          value: "{{ 'true' if kube_vip_arp | default(true) | bool else 'false' }}"
+        - name: bgp_enable
+          value: "{{ 'true' if kube_vip_bgp | default(false) | bool else 'false' }}"
         - name: port
           value: "6443"
 {% if kube_vip_iface %}
@@ -54,6 +56,24 @@ spec:
           value: "2"
         - name: address
           value: {{ apiserver_endpoint }}
+{% if kube_vip_bgp | default(false) | bool %}
+{% if kube_vip_bgp_routerid is defined %}
+        - name: bgp_routerid
+          value: "{{ kube_vip_bgp_routerid }}"
+{% endif %}
+{% if kube_vip_bgp_as is defined %}
+        - name: bgp_as
+          value: "{{ kube_vip_bgp_as }}"
+{% endif %}
+{% if kube_vip_bgp_peeraddress is defined %}
+        - name: bgp_peeraddress
+          value: "{{ kube_vip_bgp_peeraddress }}"
+{% endif %}
+{% if kube_vip_bgp_peeras is defined %}
+        - name: bgp_peeras
+          value: "{{ kube_vip_bgp_peeras }}"
+{% endif %}
+{% endif %}
         image: ghcr.io/kube-vip/kube-vip:{{ kube_vip_tag_version }}
         imagePullPolicy: Always
         name: kube-vip


### PR DESCRIPTION
With the kube_vip_bgp parameter it is possible to enable the kube-vip BGP support (https://kube-vip.io/docs/modes/bgp/).

The configuration is possible with the following new parameters:

* kube_vip_bgp_routerid
* kube_vip_bgp_as
* kube_vip_bgp_peeraddress
* kube_vip_bgp_peeras