### PR TITLE
Make it possible to disable the creation of the kubectl/crictl symlinks

### DIFF
--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -146,12 +146,14 @@
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/kubectl
     state: link
+  when: k3s_create_kubectl_symlink | default(true) | bool
 
 - name: Create crictl symlink
   file:
     src: /usr/local/bin/k3s
     dest: /usr/local/bin/crictl
     state: link
+  when: k3s_create_crictl_symlink | default(true) | bool
 
 - name: Get contents of manifests folder
   find:


### PR DESCRIPTION
If k3s_create_kubectl_symlink is set to false the kubectl symlink will not be created.

If k3s_create_crictl_symlink is set to false the crictl symlink will not be created.

By default the symlinks will be created. The default behavior is not changed.