### PR TITLE
k3s_server: add missing parameter descriptions

### DIFF
--- a/roles/k3s_server/meta/main.yml
+++ b/roles/k3s_server/meta/main.yml
@@ -26,6 +26,16 @@ argument_specs:
         description: Name of the master group
         default: master
 
+      k3s_create_kubectl_symlink:
+        description: Create the kubectl -> k3s symlink
+        default: false
+        type: bool
+
+      k3s_create_crictl_symlink:
+        description: Create the crictl -> k3s symlink
+        default: false
+        type: bool
+
       kube_vip_arp:
         description: Enables ARP broadcasts from Leader
         default: true


### PR DESCRIPTION
The commit 3a20500f9c4b2d160bf7fce127ab91850851dec6 has introduced argument specs in the role meta information. These two parameters were still missing there.

Realted to 2d0596209ee542d728830d4f9e97686ac1c28f26