### PR TITLE
fix: fix raspberry pi preparation for ubuntu 24.04

### DIFF
--- a/roles/raspberrypi/tasks/setup/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/setup/Ubuntu.yml
@@ -11,3 +11,4 @@
   ansible.builtin.apt:
     name: linux-modules-extra-raspi
     state: present
+  when: ansible_distribution_version is version('24.04', '<')

--- a/roles/raspberrypi/tasks/teardown/Ubuntu.yml
+++ b/roles/raspberrypi/tasks/teardown/Ubuntu.yml
@@ -3,3 +3,4 @@
   ansible.builtin.apt:
     name: linux-modules-extra-raspi
     state: absent
+  when: ansible_distribution_version is version('24.04', '<')


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

This package does not exist anymore on Ubuntu 24 and is integrated into the kernel, so we don't need an alternative.

See also
- https://packages.ubuntu.com/search?keywords=linux-modules-extra-raspi&searchon=names 
- https://github.com/k3s-io/k3s-ansible/pull/346

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
