### PR TITLE
k3s_server_post: add cilium_bgp_neighbors parameter

### DIFF
--- a/roles/k3s_server_post/defaults/main.yml
+++ b/roles/k3s_server_post/defaults/main.yml
@@ -15,6 +15,8 @@ cilium_bgp: false
 cilium_exportPodCIDR: true  # noqa var-naming
 cilium_bgp_my_asn: 64513
 cilium_bgp_peer_asn: 64512
+cilium_bgp_neighbors: []
+cilium_bgp_neighbors_groups: ['k3s_all']
 cilium_bgp_lb_cidr: 192.168.31.0/24
 cilium_hubble: true
 cilium_mode: native

--- a/roles/k3s_server_post/meta/main.yml
+++ b/roles/k3s_server_post/meta/main.yml
@@ -66,6 +66,14 @@ argument_specs:
         description: BGP peer address
         default: ~
 
+      cilium_bgp_neighbors:
+        description: List of BGP peer ASN & address pairs
+        default: []
+
+      cilium_bgp_neighbors_groups:
+        description: Inventory group in which to search for additional cilium_bgp_neighbors parameters to merge.
+        default: ['k3s_all']
+
       cilium_bgp_lb_cidr:
         description: BGP load balancer IP range
         default: 192.168.31.0/24

--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -221,6 +221,11 @@
     - name: Configure Cilium BGP
       when: cilium_bgp
       block:
+        - name: Set _cilium_bgp_neighbors fact
+          ansible.builtin.set_fact:
+            _cilium_bgp_neighbors: "{{ lookup('community.general.merge_variables', '^cilium_bgp_neighbors__.+$', initial_value=cilium_bgp_neighbors, groups=cilium_bgp_neighbors_groups) }}"  # yamllint disable-line rule:line-length
+          when: cilium_bgp_neighbors | length > 0
+
         - name: Copy BGP manifests to first master
           ansible.builtin.template:
             src: cilium.crs.j2

--- a/roles/k3s_server_post/templates/cilium.crs.j2
+++ b/roles/k3s_server_post/templates/cilium.crs.j2
@@ -7,6 +7,19 @@ spec: # CiliumBGPPeeringPolicySpec
  - localASN: {{ cilium_bgp_my_asn }}
    exportPodCIDR: {{ cilium_exportPodCIDR | default('true') }}
    neighbors: # []CiliumBGPNeighbor
+{% if _cilium_bgp_neighbors | length > 0 %}
+{% for item in _cilium_bgp_neighbors %}
+    - peerAddress: '{{ item.peer_address + "/32"}}'
+      peerASN: {{ item.peer_asn }}
+      eBGPMultihopTTL: 10
+      connectRetryTimeSeconds: 120
+      holdTimeSeconds: 90
+      keepAliveTimeSeconds: 30
+      gracefulRestart:
+        enabled: true
+        restartTimeSeconds: 120
+{% endfor %}
+{% else %}
     - peerAddress: '{{ cilium_bgp_peer_address + "/32"}}'
       peerASN: {{ cilium_bgp_peer_asn }}
       eBGPMultihopTTL: 10
@@ -16,6 +29,7 @@ spec: # CiliumBGPPeeringPolicySpec
       gracefulRestart:
         enabled: true
         restartTimeSeconds: 120
+{% endif %}
    serviceSelector:
       matchExpressions:
          - {key: somekey, operator: NotIn, values: ['never-used-value']}


### PR DESCRIPTION
With the cilium_bgp_neighbors parameter it is possible to define
multiple BGP peer ASN & address pairs for Cilium.

Sample:

```
cilium_bgp_neighbors:
  - peer_address: 192.168.128.10
    peer_asn: 64512
  - peer_address: 192.168.128.11
    peer_asn: 64512
  - peer_address: 192.168.128.12
    peer_asn: 64512
```

It is possible to merge further lists with cilium_bgp_neighbors__*
parameters.

Sample:

```
cilium_bgp_neighbors__extra:
  - peer_address: 192.168.128.10
    peer_asn: 64512
cilium_bgp_neighbors:
  - peer_address: 192.168.128.11
    peer_asn: 64512
  - peer_address: 192.168.128.12
    peer_asn: 64512
```

This will result in the following list of BGP peer ASN & address pairs:

```
- peer_address: 192.168.128.10
  peer_asn: 64512
- peer_address: 192.168.128.11
  peer_asn: 64512
- peer_address: 192.168.128.12
  peer_asn: 64512
```