### PR TITLE
feat(k3s): Add option to set MetalLB interfaces

### DIFF
--- a/roles/k3s_server_post/defaults/main.yml
+++ b/roles/k3s_server_post/defaults/main.yml
@@ -30,3 +30,4 @@ metal_lb_mode: layer2
 metal_lb_available_timeout: 240s
 metal_lb_controller_tag_version: v0.14.3
 metal_lb_ip_range: 192.168.30.80-192.168.30.90
+metal_lb_interfaces:

--- a/roles/k3s_server_post/meta/main.yml
+++ b/roles/k3s_server_post/meta/main.yml
@@ -129,6 +129,10 @@ argument_specs:
         description: MetalLB ip range for load balancer
         default: 192.168.30.80-192.168.30.90
 
+      metal_lb_interfaces:
+        description: MetalLB interfaces to announce on. By default, announces on all interfaces.
+        default:
+
       metal_lb_controller_tag_version:
         description: Image tag for MetalLB
         default: v0.14.3

--- a/roles/k3s_server_post/templates/metallb.crs.j2
+++ b/roles/k3s_server_post/templates/metallb.crs.j2
@@ -21,6 +21,13 @@ kind: L2Advertisement
 metadata:
   name: default
   namespace: metallb-system
+{% if metal_lb_interfaces %}
+spec:
+  interfaces:
+  {% for interface in metal_lb_interfaces %}
+    - {{ interface }}
+  {% endfor %}
+{% endif %}
 {% endif %}
 {% if metal_lb_mode == "bgp" %}
 ---


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->
- Add option to limit MetalLB announce to specific network interfaces
-
-

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
