### PR TITLE
k3s_server: add kube_vip_bgp_peers parameter

### DIFF
--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -16,6 +16,9 @@ kube_vip_bgp_as: "64513"
 kube_vip_bgp_peeraddress: 192.168.30.1
 kube_vip_bgp_peeras: "64512"
 
+kube_vip_bgp_peers: []
+kube_vip_bgp_peers_groups: ['k3s_master']
+
 metal_lb_controller_tag_version: v0.14.3
 metal_lb_speaker_tag_version: v0.14.3
 metal_lb_type: native

--- a/roles/k3s_server/meta/main.yml
+++ b/roles/k3s_server/meta/main.yml
@@ -62,6 +62,14 @@ argument_specs:
         description: Defines the AS for the kube-vip BGP peer
         default: "64512"
 
+      kube_vip_bgp_peers:
+        description: List of BGP peer ASN & address pairs
+        default: []
+
+      kube_vip_bgp_peers_groups:
+        description: Inventory group in which to search for additional kube_vip_bgp_peers parameters to merge.
+        default: ['k3s_master']
+
       kube_vip_iface:
         description:
           - Explicitly define an interface that ALL control nodes

--- a/roles/k3s_server/tasks/vip.yml
+++ b/roles/k3s_server/tasks/vip.yml
@@ -1,4 +1,8 @@
 ---
+- name: Set _kube_vip_bgp_peers fact
+  ansible.builtin.set_fact:
+    _kube_vip_bgp_peers: "{{ lookup('community.general.merge_variables', '^kube_vip_bgp_peers__.+$', initial_value=kube_vip_bgp_peers, groups=kube_vip_bgp_peers_groups) }}"  # yamllint disable-line rule:line-length
+
 - name: Create manifests directory on first master
   ansible.builtin.file:
     path: /var/lib/rancher/k3s/server/manifests

--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -61,6 +61,10 @@ spec:
         - name: bgp_routerid
           value: "{{ kube_vip_bgp_routerid }}"
 {% endif %}
+{% if _kube_vip_bgp_peers | length > 0 %}
+        - name: bgppeers
+          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ',') | join(':') }}"  # yamllint disable-line rule:line-length
+{% else %}
 {% if kube_vip_bgp_as is defined %}
         - name: bgp_as
           value: "{{ kube_vip_bgp_as }}"
@@ -72,6 +76,7 @@ spec:
 {% if kube_vip_bgp_peeras is defined %}
         - name: bgp_peeras
           value: "{{ kube_vip_bgp_peeras }}"
+{% endif %}
 {% endif %}
 {% endif %}
         image: ghcr.io/kube-vip/kube-vip:{{ kube_vip_tag_version }}


### PR DESCRIPTION
With the kube_vip_bgp_peers it is possible to define multiple BGP peer ASN & address pairs for kube-vip.

Sample:

```
kube_vip_bgp_peers:
  - peer_address: 192.168.128.10
    peer_asn: 64512
  - peer_address: 192.168.128.11
    peer_asn: 64512
  - peer_address: 192.168.128.12
    peer_asn: 64512
```

It is possible to merge further lists with kube_vip_bgp_peers__* parameters.

Sample:

```
kube_vip_bgp_peers__extra:
  - peer_address: 192.168.128.10
    peer_asn: 64512
kube_vip_bgp_peers:
  - peer_address: 192.168.128.11
    peer_asn: 64512
  - peer_address: 192.168.128.12
    peer_asn: 64512
```

This will result in the following list of BGP peer ASN & address pairs:

```
- peer_address: 192.168.128.10
  peer_asn: 64512
- peer_address: 192.168.128.11
  peer_asn: 64512
- peer_address: 192.168.128.12
  peer_asn: 64512
```