### PR TITLE
k3s_server: fix error in vip.yaml template

### DIFF
--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -62,8 +62,8 @@ spec:
           value: "{{ kube_vip_bgp_routerid }}"
 {% endif %}
 {% if _kube_vip_bgp_peers | length > 0 %}
-        - name: bgppeers
-          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ',') | join(':') }}"  # yamllint disable-line rule:line-length
+        - name: bgp_peers
+          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ':') | join(',') }}"  # yamllint disable-line rule:line-length
 {% else %}
 {% if kube_vip_bgp_as is defined %}
         - name: bgp_as


### PR DESCRIPTION
The name of the variable is bgp_peers and not bgppeers.

The value of the bgppeers variable is wrong. It should be
<address:AS:password:multihop> and not <address,AS,password,multihop>.