### PR TITLE
Fix agents token containing % error

### DIFF
--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -11,7 +11,7 @@ ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s agent \
   --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 \
   {% if is_pxe_booted | default(false) %}--snapshotter native \
-  {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} \
+  {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) | replace( '%', '%%' ) }} \
   {{ extra_agent_args }}
 KillMode=process
 Delegate=yes


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Escape % signs in --token argument in systemd scripts

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀

Fixes #624 