### PR TITLE
Fetch default interface from ansible facts not just ens0

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -8,7 +8,7 @@ systemd_dir: /etc/systemd/system
 system_timezone: Your/Timezone
 
 # interface which will be used for flannel
-flannel_iface: eth0
+flannel_iface: "{{ ansible_facts.default_ipv4.interface | default( 'ens0' ) }}"
 
 # uncomment calico_iface to use tigera operator/calico cni instead of flannel https://docs.tigera.io/calico/latest/about
 # calico_iface: "eth0"


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Fetches default interface for each host from ansible facts rather than hardcoding ens0

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀

Fixes #621 