### PR TITLE
Fix kube-vip bgp_peers variable

### DIFF
--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -61,14 +61,14 @@ spec:
         - name: bgp_routerid
           value: "{{ kube_vip_bgp_routerid }}"
 {% endif %}
-{% if _kube_vip_bgp_peers | length > 0 %}
-        - name: bgppeers
-          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ',') | join(':') }}"  # yamllint disable-line rule:line-length
-{% else %}
 {% if kube_vip_bgp_as is defined %}
         - name: bgp_as
           value: "{{ kube_vip_bgp_as }}"
 {% endif %}
+{% if _kube_vip_bgp_peers | length > 0 %}
+        - name: bgp_peers
+          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ':') | join(',') }}"  # yamllint disable-line rule:line-length
+{% else %}
 {% if kube_vip_bgp_peeraddress is defined %}
         - name: bgp_peeraddress
           value: "{{ kube_vip_bgp_peeraddress }}"


### PR DESCRIPTION
# Proposed Changes
Solution for issue: https://github.com/techno-tim/k3s-ansible/issues/633

- Rearranged bgp_as so it does still configure even if bgp_peers are true.
- Resolved spelling error bgp_peers
- Swapped "," and ":" for correct joining of variables.

## Checklist

- [*] Tested locally
- [*] Ran `site.yml` playbook
- [*] Ran `reset.yml` playbook
- [*] Did not add any unnecessary changes
- [*] Ran pre-commit install at least once before committing
- [*] 🚀
