### PR TITLE
Added support to enable or disable Envoy in the Cilium installation using a new `cilium_envoy` variable.

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -21,6 +21,7 @@ calico_tag: v3.28.0 # calico version tag
 cilium_mode: native # native when nodes on same subnet or using bgp, else set routed
 cilium_tag: v1.16.0 # cilium version tag
 cilium_hubble: true # enable hubble observability relay and ui
+cilium_envoy: true  # enable/disable envoy proxy 
 
 # if using calico or cilium, you may specify the cluster pod cidr pool
 cluster_cidr: 10.52.0.0/16

--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -180,6 +180,7 @@
         --helm-set hubble.enabled={{ "true" if cilium_hubble else "false" }}
         --helm-set hubble.relay.enabled={{ "true" if cilium_hubble else "false" }}
         --helm-set hubble.ui.enabled={{ "true" if cilium_hubble else "false" }}
+        --helm-set envoy.enabled={{ "true" if cilium_envoy else "false" }}
         {% if kube_proxy_replacement is not false %}
         --helm-set bpf.loadBalancer.algorithm={{ bpf_lb_algorithm }}
         --helm-set bpf.loadBalancer.mode={{ bpf_lb_mode }}


### PR DESCRIPTION
# Proposed Changes

- Added support to enable or disable Envoy in the Cilium installation using a new `cilium_envoy` variable.

- Updated the cilium install/upgrade command to include `--helm-set envoy.enabled={{ "true" if cilium_envoy else "false" }`.

- Ensured backward compatibility: if `cilium_envoy` is not set, Envoy is disabled by default.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
