### PR TITLE
upgrade to k3s_version: v1.33.1+k3s1

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.30.2+k3s2
+k3s_version: v1.33.1+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system


### PR DESCRIPTION
[deploy_logs.txt](https://github.com/user-attachments/files/20711941/deploy_logs.txt)
[reset_logs.txt](https://github.com/user-attachments/files/20710908/reset_logs.txt)
![image](https://github.com/user-attachments/assets/5c3270c4-a1d2-4fe5-acae-8292551da596)


upgrade to k3s_version: v1.33.1+k3s1

# Proposed Changes
<!--- Provide a general summary of your changes -->

- upgrade to k3s_version: v1.33.1+k3s1
- Deployed on local cluster running Rocky 9 Nodes. 
- Changed k3s_version: v1.30.2+k3s2  to v1.33.1+k3s1 and re ran ansible script. Nothing appears to have broke 🥳

![image](https://github.com/user-attachments/assets/1b945189-2b05-4e9f-bc38-27c575779d25)


## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [x] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [x] 🚀
