### PR TITLE
feat: allow staggered reboot of K3s cluster nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ ansible-playbook reset.yml -i inventory/my-cluster/hosts.ini
 
 >You should also reboot these nodes due to the VIP not being destroyed
 
+### ⏻️ Reboot Cluster Nodes
+
+The cluster nodes can all be rebooted at once, or staggered. For a staggered reboot, you can use `concurrent_reboots` to specify
+how many nodes can be rebooted simultaneously. You can also use `wait_seconds_after_reboot` to specify how many seconds wait
+time there should be between a successful reboot and starting the next reboot; this could be helpful for waiting to restart pods.
+
+```bash
+ansible-playbook reboot.yml -i inventory/my-cluster/hosts.ini --extra-vars 'concurrent_reboots=2 wait_seconds_after_reboot=30'
+```
+
 ## ⚙️ Kube Config
 
 To copy your `kube config` locally so that you can access your **Kubernetes** cluster run:

--- a/reboot.yml
+++ b/reboot.yml
@@ -2,9 +2,27 @@
 - name: Reboot k3s_cluster
   hosts: k3s_cluster
   gather_facts: true
+
+  # concurrent_reboots defines how many hosts to reboot concurrently, if not defined, all hosts rebooted at once
+  serial: "{{ concurrent_reboots | default('100%') }}"
+
   tasks:
-    - name: Reboot the nodes (and Wait upto 5 mins max)
-      become: true
+    - name: >-
+        {{
+          'Reboot all nodes at once'
+          if (concurrent_reboots is not defined)
+          else 'Reboot nodes with concurrency of ' ~ concurrent_reboots
+        }}
       ansible.builtin.reboot:
         reboot_command: "{{ custom_reboot_command | default(omit) }}"
         reboot_timeout: 300
+        test_command: >-
+          {{ 'kubectl get nodes' if 'master' in group_names else 'whoami' }}
+
+    - name: Optional wait after reboot before next rebooting next node
+      ansible.builtin.pause:
+        seconds: "{{ wait_seconds_after_reboot | default(0) }}"
+      when: >-
+        concurrent_reboots is defined and
+        wait_seconds_after_reboot is defined and
+        wait_seconds_after_reboot | int > 0


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

Without specifying any new options, the reboot workflow runs like before; master nodes just got another check for being online. 

As an option, you can now specify if you want to have a staggered reboot, i.e. not so many machines rebooting concurrently. It is then also possible to add a wait after rebooting a single machine/a few machines. The instructions on how to set these two options should become clear when reading the documentation.

## Checklist

- [x] Tested locally --> Tried on own cluster
- [ ] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [ ] Ran pre-commit install at least once before committing
- [x] 🚀
