### PR TITLE
Add steps to install kernel-modules-extra if br_netfilter module is not found on RedHat family

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ansible-playbook site.yml
+ansible-playbook site.yml -i inventory/my-cluster/hosts.ini

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -93,6 +93,8 @@ kube_vip_tag_version: v1.0.0
 # (uncomment to use kube-vip for services instead of MetalLB)
 # kube_vip_lb_ip_range: "192.168.30.80-192.168.30.90"
 
+metal_lb_install: true
+
 # metallb type frr or native
 metal_lb_type: native
 

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.30.2+k3s2
+k3s_version: v1.33.4+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system
@@ -13,13 +13,13 @@ flannel_iface: eth0
 # uncomment calico_iface to use tigera operator/calico cni instead of flannel https://docs.tigera.io/calico/latest/about
 # calico_iface: "eth0"
 calico_ebpf: false # use eBPF dataplane instead of iptables
-calico_tag: v3.28.0 # calico version tag
+calico_tag: v3.30.3 # calico version tag
 
 # uncomment cilium_iface to use cilium cni instead of flannel or calico
 # ensure v4.19.57, v5.1.16, v5.2.0 or more recent kernel
 # cilium_iface: "eth0"
 cilium_mode: native # native when nodes on same subnet or using bgp, else set routed
-cilium_tag: v1.16.0 # cilium version tag
+cilium_tag: v1.18.2 # cilium version tag
 cilium_hubble: true # enable hubble observability relay and ui
 
 # if using calico or cilium, you may specify the cluster pod cidr pool
@@ -84,7 +84,7 @@ extra_agent_args: >-
   {{ extra_args }}
 
 # image tag for kube-vip
-kube_vip_tag_version: v0.8.2
+kube_vip_tag_version: v1.0.0
 
 # tag for kube-vip-cloud-provider manifest
 # kube_vip_cloud_provider_tag_version: "main"
@@ -105,8 +105,8 @@ metal_lb_mode: layer2
 # metal_lb_bgp_peer_address: "192.168.30.1"
 
 # image tag for metal lb
-metal_lb_speaker_tag_version: v0.14.8
-metal_lb_controller_tag_version: v0.14.8
+metal_lb_speaker_tag_version: v0.15.2
+metal_lb_controller_tag_version: v0.15.2
 
 # metallb ip range for load balancer
 metal_lb_ip_range: 192.168.30.80-192.168.30.90

--- a/reset_n_deploy.sh
+++ b/reset_n_deploy.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+### Reset K3s
+ansible-playbook reset.yml -i inventory/my-cluster/hosts.ini
+
+### Deploy K3s
+ansible-playbook site.yml -i inventory/my-cluster/hosts.ini

--- a/roles/k3s_server/meta/main.yml
+++ b/roles/k3s_server/meta/main.yml
@@ -90,6 +90,11 @@ argument_specs:
         description: IP range for kube-vip load balancer
         default: ~
 
+      metal_lb_install:
+        description: Install MetalLB
+        default: true
+        type: bool
+
       metal_lb_controller_tag_version:
         description: Image tag for MetalLB
         default: v0.14.3

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -24,10 +24,11 @@
 
 - name: Deploy vip manifest
   ansible.builtin.include_tasks: vip.yml
+
 - name: Deploy metallb manifest
   ansible.builtin.include_tasks: metallb.yml
   tags: metallb
-  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined)
+  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined) and metal_lb_install
 
 - name: Deploy kube-vip manifest
   ansible.builtin.include_tasks: kube-vip.yml

--- a/roles/k3s_server_post/meta/main.yml
+++ b/roles/k3s_server_post/meta/main.yml
@@ -121,6 +121,11 @@ argument_specs:
         description: IP range for kube-vip load balancer
         default: ~
 
+      metal_lb_install:
+        description: Install MetalLB
+        default: true
+        type: bool
+
       metal_lb_available_timeout:
         description: Wait for MetalLB resources
         default: 240s

--- a/roles/k3s_server_post/tasks/main.yml
+++ b/roles/k3s_server_post/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: Deploy metallb pool
   ansible.builtin.include_tasks: metallb.yml
   tags: metallb
-  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined)
+  when: kube_vip_lb_ip_range is not defined and (not cilium_bgp or cilium_iface is not defined) and metal_lb_install
 
 - name: Remove tmp directory used for manifests
   ansible.builtin.file:

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -33,6 +33,32 @@
     reload: true
   tags: sysctl
 
+- name: Check if br_netfilter module exists
+  ansible.builtin.shell: |
+    find /lib/modules/$(uname -r) -name "br_netfilter.ko*" | wc -l
+  register: br_netfilter_exists
+  changed_when: false
+  when: ansible_os_family == "RedHat"
+
+- name: Install kernel-modules-extra if br_netfilter missing
+  ansible.builtin.yum:
+    name: kernel-modules-extra
+    state: present
+    update_cache: yes
+  register: kernel_modules_installed
+  when:
+    - ansible_os_family == "RedHat"
+    - br_netfilter_exists.stdout | int == 0
+
+- name: Reboot after kernel-modules-extra installation
+  ansible.builtin.reboot:
+    reboot_command: "{{ custom_reboot_command | default(omit) }}"
+    reboot_timeout: 3600
+  when:
+    - ansible_os_family == "RedHat"
+    - kernel_modules_installed is defined
+    - kernel_modules_installed is changed
+
 - name: Add br_netfilter to /etc/modules-load.d/
   ansible.builtin.copy:
     content: br_netfilter


### PR DESCRIPTION
# Proposed Changes
<!--- Provide a general summary of your changes -->

- Added steps to install kernel-modules-extra if br_netfilter module is not found on RedHat family
- Bumped versions of k3s, calico, cilium, kube-vip, metallb versions just in case since new releases may have better nftables support

Backgrounds:
- Had trouble running playbook since RockyLinux 10's cloud image lacks extra kernel modules which contains br_netfilter
- RedHat has removed all iptables and iptables shim layer by default starting from RHEL 10

Notes:
- Have only tested basic bridge in flannel configuration. Needs testing in calico or cilium env.

## Checklist

- [x] Tested locally
- [x] Ran `site.yml` playbook
- [ ] Ran `reset.yml` playbook
- [x] Did not add any unnecessary changes
- [x] Ran pre-commit install at least once before committing
- [ ] 🚀
