### PR TITLE
fix(token): escape percent signs used in k3s token

### DIFF
--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -11,7 +11,7 @@ ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s agent \
   --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 \
   {% if is_pxe_booted | default(false) %}--snapshotter native \
-  {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} \
+  {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) | replace( '%', '%%' ) }} \
   {{ extra_agent_args }}
 KillMode=process
 Delegate=yes

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -33,7 +33,7 @@ server_init_args: >-
     {% else %}
       --server https://{{ hostvars[groups[group_name_master | default('master')][0]].k3s_node_ip | split(",") | first | ansible.utils.ipwrap }}:6443
     {% endif %}
-    --token {{ k3s_token }}
+    --token {{ k3s_token | replace('%', '%%') }}
   {% endif %}
   {{ extra_server_args }}
 


### PR DESCRIPTION
## Summary

Tokens containing a `%` character cause systemd to reject the unit with `failed to resolve unit specifiers invalid slot`, because systemd treats `%` as a specifier in `ExecStart`. This escapes the token so `%`-containing values work for both agents and the server bootstrap.

## Changes

- `roles/k3s_agent/templates/k3s.service.j2`: escape `%` -> `%%` in the agent unit's `--token`.
- `roles/k3s_server/defaults/main.yml`: escape `%` -> `%%` in `server_init_args`, which covers the first-master and joining-master `systemd-run k3s-init` bootstrap paths.

A token with no `%` is unchanged (a no-op), so existing users are unaffected.

## Related

- Fixes #624
- Supersedes #625, which only covered the agent unit and could not be updated because its head branch lives in a contributor fork.

## Validation

- pre-commit (ansible-lint, yamllint) passes.
- `git diff --check` passes.
- Rebases cleanly onto current master.