### PR TITLE
fix(prereq): install kernel-modules-extra when br_netfilter is missing

### DIFF
--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -33,6 +33,27 @@
     reload: true
   tags: sysctl
 
+- name: Check if br_netfilter module exists
+  ansible.builtin.shell: |
+    set -o pipefail
+    find /lib/modules/$(uname -r) -name "br_netfilter.ko*" | wc -l
+  args:
+    executable: /bin/bash
+  register: br_netfilter_exists
+  changed_when: false
+  when: ansible_os_family == "RedHat"
+  tags: sysctl
+
+- name: Install kernel-modules-extra if br_netfilter missing
+  ansible.builtin.yum:
+    name: kernel-modules-extra
+    state: present
+    update_cache: true
+  register: kernel_modules_installed
+  when:
+    - ansible_os_family == "RedHat"
+    - br_netfilter_exists.stdout | int == 0
+
 - name: Add br_netfilter to /etc/modules-load.d/
   ansible.builtin.copy:
     content: br_netfilter


### PR DESCRIPTION
## Summary

On RHEL 10 / Rocky Linux 10 the default cloud image does not ship the `kernel-modules-extra` package that contains the `br_netfilter` module, so the prereq role's `modprobe br_netfilter` fails on RedHat-family hosts.

## Changes

- Detect whether `br_netfilter` exists for the running kernel.
- Install `kernel-modules-extra` when the module is absent (RedHat family only).
- No reboot is required: the module is installed for the currently running kernel and becomes available to `modprobe` immediately.

## Validation

- pre-commit (ansible-lint, yamllint) passes.
- `git diff --check` passes.
- Rebases cleanly onto current master.