### PR TITLE
fix(ci): retry transient DNS failures on remote downloads and cilium install

### DIFF
--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -23,6 +23,12 @@ metal_lb_controller_tag_version: v0.16.0
 metal_lb_speaker_tag_version: v0.16.0
 metal_lb_type: native
 
+# Shared retry/delay for remote manifest and asset downloads. The CI runner's
+# resolver intermittently times out on GitHub-hosted domains (helm.cilium.io,
+# raw.githubusercontent.com, github.com), so retry transient DNS/network failures.
+download_retries: 5
+download_delay: 10
+
 retry_count: 20
 
 # yamllint disable rule:line-length

--- a/roles/k3s_server/tasks/kube-vip.yml
+++ b/roles/k3s_server/tasks/kube-vip.yml
@@ -15,6 +15,10 @@
     owner: root
     group: root
     mode: "0644"
+  register: kube_vip_manifest_download
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: kube_vip_manifest_download is succeeded
   when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: Copy kubevip configMap manifest to first master

--- a/roles/k3s_server/tasks/metallb.yml
+++ b/roles/k3s_server/tasks/metallb.yml
@@ -15,6 +15,10 @@
     owner: root
     group: root
     mode: "0644"
+  register: metallb_manifest_download
+  retries: "{{ download_retries }}"
+  delay: "{{ download_delay }}"
+  until: metallb_manifest_download is succeeded
   when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
 
 - name: Set image versions in manifest for metallb-{{ metal_lb_type }}

--- a/roles/k3s_server_post/tasks/calico.yml
+++ b/roles/k3s_server_post/tasks/calico.yml
@@ -18,6 +18,10 @@
         owner: root
         group: root
         mode: "0755"
+      register: calico_crd_download
+      retries: "{{ download_retries }}"
+      delay: "{{ download_delay }}"
+      until: calico_crd_download is succeeded
 
     - name: "Download to first master: manifest for Tigera Operator and Calico CRDs"
       ansible.builtin.get_url:
@@ -26,6 +30,10 @@
         owner: root
         group: root
         mode: "0755"
+      register: tigera_operator_download
+      retries: "{{ download_retries }}"
+      delay: "{{ download_delay }}"
+      until: tigera_operator_download is succeeded
 
     - name: Apply Calico CRD bundle with server-side apply
       ansible.builtin.command: >-

--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -66,6 +66,10 @@
             - .tar.gz.sha256sum
           vars:
             cilium_base_url: https://github.com/cilium/cilium-cli/releases/download/{{ cilium_cli_tag }}
+          register: cilium_cli_download
+          retries: "{{ download_retries }}"
+          delay: "{{ download_delay }}"
+          until: cilium_cli_download is succeeded
 
         - name: Verify the downloaded tarball
           ansible.builtin.shell: |
@@ -182,6 +186,13 @@
         KUBECONFIG: "{{ ansible_user_dir }}/.kube/config"
       register: cilium_install_result
       changed_when: cilium_install_result.rc == 0
+      # cilium install/upgrade fetches the Helm chart from helm.cilium.io, which is
+      # fronted by GitHub Pages and can transiently fail DNS resolution through the
+      # host resolver (intermittent "lookup helm.cilium.io ... i/o timeout"). Retry
+      # so a transient name/network failure does not abort the whole converge play.
+      until: cilium_install_result.rc == 0
+      retries: "{{ download_retries }}"
+      delay: "{{ download_delay }}"
       when: cilium_installed.rc != 0 or cilium_needs_update
 
     - name: Wait for Cilium resources


### PR DESCRIPTION
## Description

The CI runner's systemd-resolved resolver intermittently times out resolving GitHub-hosted domains such as `helm.cilium.io`, `raw.githubusercontent.com`, and `github.com`. This caused the `cilium` molecule scenario to fail with:

```
looks like "https://helm.cilium.io" is not a valid chart repository or cannot be reached:
  Get "https://helm.cilium.io/index.yaml": dial tcp: lookup helm.cilium.io on 127.0.0.53:53:
  read udp ... i/o timeout
```

The failure was reproduced on the runner box itself: the stub resolver timed out on `helm.cilium.io` (and `get.helm.sh`) intermittently, while a direct query to a public resolver (`1.1.1.1`) always succeeded. It is a transient DNS/network flake, not a URL or code error.

## Change

Add shared `download_retries`/`download_delay` defaults and apply an Ansible retry (`register`/`until`/`retries`/`delay`) to every network fetch so a transient failure retries instead of aborting the whole converge play:

- Calico CRD bundle and Tigera operator manifest downloads
- Cilium CLI download (GitHub releases)
- `cilium install`/`cilium upgrade` command (fetches the Helm chart from `helm.cilium.io`)
- kube-vip cloud provider manifest download
- MetalLB manifest download

## Validation

- `yamllint` and `ansible-lint` pass
- Full `pre-commit run --all-files` passes
- `ansible-playbook site.yml --syntax-check` passes