### PR TITLE
chore(deps): bump k3s to v1.36.3 and kube-vip to v1.2.3

### DIFF
--- a/.github/scripts/test-kube-vip-manifest.py
+++ b/.github/scripts/test-kube-vip-manifest.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Render the kube-vip DaemonSet template and assert env key correctness.
 
-kube-vip v1.2.2 reads `bgp_peers` and `vip_subnet`; it ignores the older
+kube-vip v1.2.3 reads `bgp_peers` and `vip_subnet`; it ignores the older
 `bgppeers` and `vip_cidr` names. This test proves the rendered manifest uses
 the keys the target image actually parses.
 """
@@ -74,7 +74,7 @@ def render(env, extra_vars):
             {"peer_address": "192.168.30.1", "peer_asn": "64512"},
             {"peer_address": "192.168.30.2", "peer_asn": "64513"},
         ],
-        "kube_vip_tag_version": "v1.2.2",
+        "kube_vip_tag_version": "v1.2.3",
     }
     base_vars.update(extra_vars)
     template = env.get_template("vip.yaml.j2")
@@ -105,8 +105,8 @@ def main():
         fail("rendered manifest still uses the ignored vip_cidr key")
     if "192.168.30.1:64512,192.168.30.2:64513" not in output:
         fail("bgp_peers value is not comma-separated address:ASN entries")
-    if "ghcr.io/kube-vip/kube-vip:v1.2.2" not in output:
-        fail("kube-vip image tag is not v1.2.2")
+    if "ghcr.io/kube-vip/kube-vip:v1.2.3" not in output:
+        fail("kube-vip image tag is not v1.2.3")
 
     # BGP enabled with no merged peers: single-peer fallback vars, no bgp_peers.
     output = render(

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ See the commands [here](https://technotim.com/posts/k3s-etcd-ansible/#testing-yo
 | `k3s_server` | `kube_vip_bgp_peers_groups` | list | `['k3s_master']` | Not required | Inventory group in which to search for additional `kube_vip_bgp_peers` parameters to merge. |
 | `k3s_server` | `kube_vip_iface` | string | `~` | Not required | Explicitly define an interface that ALL control nodes should use to propagate the VIP, define it here. Otherwise, kube-vip will determine the right interface automatically at runtime. |
 | `k3s_server` | `kube_vip_endpoint` | string | `~` | Not required | Overrides the internal address kube-vip binds/listens on, which can differ from the announced apiserver_endpoint for complex routing/tunnels. Defaults to apiserver_endpoint. |
-| `k3s_server` | `kube_vip_tag_version` | string | `v1.2.2` | Not required | Image tag for kube-vip |
+| `k3s_server` | `kube_vip_tag_version` | string | `v1.2.3` | Not required | Image tag for kube-vip |
 | `k3s_server` | `kube_vip_cloud_provider_tag_version` | string | `v0.0.12` | Not required | Tag for kube-vip-cloud-provider manifest when enable |
 | `k3s_server` | `kube_vip_enabled` | bool | `true` | Not required | Enable kube-vip install, covering both the control-plane VIP and the service load balancer. Set false to skip kube-vip entirely (single node or external LB). |
 | `k3s_server`, `k3_server_post` | `kube_vip_lb_ip_range` | string | `~` | Not required | IP range for kube-vip load balancer |

--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.36.2+k3s1
+k3s_version: v1.36.3+k3s1
 # this is the user that has ssh access to these machines
 ansible_user: ansibleuser
 systemd_dir: /etc/systemd/system
@@ -102,7 +102,7 @@ extra_agent_args: >-
   {{ extra_args }}
 
 # image tag for kube-vip
-kube_vip_tag_version: v1.2.2
+kube_vip_tag_version: v1.2.3
 
 # enable kube-vip (covers both the control-plane VIP and service load balancing)
 # set false for a single node or when an external load balancer is used

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -9,7 +9,7 @@ kube_vip_arp: true
 kube_vip_iface:
 kube_vip_endpoint:
 kube_vip_cloud_provider_tag_version: v0.0.12
-kube_vip_tag_version: v1.2.2
+kube_vip_tag_version: v1.2.3
 
 kube_vip_bgp: false
 kube_vip_bgp_routerid: 127.0.0.1

--- a/roles/k3s_server/meta/main.yml
+++ b/roles/k3s_server/meta/main.yml
@@ -89,7 +89,7 @@ argument_specs:
 
       kube_vip_tag_version:
         description: Image tag for kube-vip
-        default: v1.2.2
+        default: v1.2.3
 
       kube_vip_cloud_provider_tag_version:
         description: Tag for kube-vip-cloud-provider manifest when enabled


### PR DESCRIPTION
### Changes in this PR

- **k3s**: v1.36.2+k3s1 -> v1.36.3+k3s1
- **kube-vip**: v1.2.2 -> v1.2.3

### Notes

- MetalLB stays at v0.16.0. The only upstream `0.16.1` artifact is the chart-only `metallb-chart-0.16.1` tag, which is not an application or image release and must not be used as the controller or speaker image tag.

### Validation

- pre-commit passes on all changed files (`yamllint`, `Ansible-lint`, `kube-vip manifest test`)